### PR TITLE
Add aws-docs MCP server reference and reorder preference questions

### DIFF
--- a/kiro-power/POWER.md
+++ b/kiro-power/POWER.md
@@ -46,9 +46,18 @@ Before starting Phase 5, add the required MCP servers to your power configuratio
       "disabled": false,
       "autoApprove": []
     },
+    "aws-docs": {
+      "command": "uvx",
+      "args": ["awslabs.aws-documentation-mcp-server@latest"],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      },
+      "disabled": false,
+      "autoApprove": []
+    },
     "opensearch-mcp-server": {
       "command": "uvx",
-      "args": ["opensearch-mcp-server@latest"],
+      "args": ["opensearch-mcp-server-py@latest"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       },
@@ -213,20 +222,20 @@ This power provides an OpenSearch Search Solution building workflow. It collects
 - Ask one preference question at a time, in this order.
 - Present each question as a numbered list and ask the user to reply with the number of their choice.
 
-  **Budget:**
-  1. Flexible
-  2. Cost-sensitive
+- If `text_search_required=true`:
+  **Query pattern:**
+  1. Mostly-exact (e.g. "Carmencita 1894")
+  2. Mostly-semantic (e.g. "early silent films about dancers")
+  3. Balanced (mix of both)
 
   **Performance priority:**
   1. Speed-first
   2. Balanced
   3. Accuracy-first
 
-- If `text_search_required=true`:
-  **Query pattern:**
-  1. Mostly-exact (e.g. "Carmencita 1894")
-  2. Mostly-semantic (e.g. "early silent films about dancers")
-  3. Balanced (mix of both)
+  **Budget:**
+  1. Flexible
+  2. Cost-sensitive
 
 - If `text_search_required=true` and query pattern is balanced or mostly-semantic, ask deployment preference as a separate follow-up question:
 

--- a/kiro-power/steering/aws-opensearch-domain.md
+++ b/kiro-power/steering/aws-opensearch-domain.md
@@ -28,6 +28,16 @@ Agentic search requires:
 
 OpenSearch Serverless does not support these requirements.
 
+## Using Official AWS Documentation
+
+If the user has the `awslabs.aws-documentation-mcp-server` MCP server configured, use it to look up the latest official AWS documentation when needed during deployment. This is especially useful for:
+- Verifying current API parameters, CLI syntax, and service limits for OpenSearch Service
+- Looking up IAM policy formats, Bedrock model IDs, and regional availability
+- Checking the latest best practices for domain configuration, security, and networking
+- Resolving errors or unexpected behavior during deployment steps
+
+Search for relevant docs proactively (e.g. "OpenSearch Service create domain", "OpenSearch ML connectors Bedrock") rather than relying solely on the instructions below, which may become outdated.
+
 ## Prerequisites
 
 Before starting Phase 5 deployment:

--- a/kiro-power/steering/aws-opensearch-serverless.md
+++ b/kiro-power/steering/aws-opensearch-serverless.md
@@ -19,6 +19,16 @@ Use OpenSearch Serverless for:
 
 **Do NOT use for Agentic Search** - use OpenSearch Domain instead (see aws-opensearch-domain.md).
 
+## Using Official AWS Documentation
+
+If the user has the `awslabs.aws-documentation-mcp-server` MCP server configured, use it to look up the latest official AWS documentation when needed during deployment. This is especially useful for:
+- Verifying current API parameters, collection types, and service limits for OpenSearch Serverless
+- Looking up IAM policy formats, data access policy syntax, and Bedrock model availability
+- Checking the latest details on automatic semantic enrichment, network policies, and encryption options
+- Resolving errors or unexpected behavior during deployment steps
+
+Search for relevant docs proactively (e.g. "OpenSearch Serverless create collection", "OpenSearch Serverless data access policy", "OpenSearch Serverless semantic enrichment") rather than relying solely on the instructions below, which may become outdated.
+
 ## Prerequisites
 
 Before starting Phase 5 deployment:


### PR DESCRIPTION

- Add `awslabs.aws-documentation-mcp-server` to POWER.md as a recommended
  MCP server for Phase 5 (AWS deployment), enabling the agent to look up
  official AWS documentation during provisioning steps.
- Add "Using Official AWS Documentation" sections to both the OpenSearch
  Domain and Serverless steering files, instructing the agent to
  proactively search official docs for current API parameters, IAM
  policies, model IDs, and service limits rather than relying solely on
  the static instructions in the steering files.
- Reorder Phase 2 preference questions so query pattern is asked before
  performance and budget, which is a more natural flow.
- Fix opensearch-mcp-server package name (opensearch-mcp-server-py).
