### PR TITLE
Fixing AWS provisioning to be deterministic flow

### DIFF
--- a/kiro/opensearch-search-builder/POWER.md
+++ b/kiro/opensearch-search-builder/POWER.md
@@ -266,16 +266,21 @@ This power provides an OpenSearch Search Solution building workflow. It collects
 ### Phase 5: Deploy to AWS OpenSearch (optional)
 - After successful local execution, offer to deploy the search strategy to AWS OpenSearch.
 - **Important**: Before starting Phase 5, guide the user to add AWS MCP servers to the power's mcp.json configuration (see AWS Setup in Onboarding section). Verify the servers are configured before proceeding.
-- Choose deployment target based on search strategy:
-  - **OpenSearch Serverless (AOSS)**: For Neural Sparse, Dense Vector, BM25, and Hybrid search
-  - **OpenSearch Domain (AOS)**: Required for Agentic Search; also supports all other strategies
-- Use AWS API MCP tools (from the aws-api-mcp-server) to provision resources.
-- Use OpenSearch MCP tools (from opensearch-mcp-server) to interact with the deployed cluster.
-- Follow the appropriate AWS deployment steering file:
-  - `aws-opensearch-serverless.md` for AOSS deployment
-  - `aws-opensearch-domain.md` for AOS deployment (Agentic Search)
-- Migrate the local configuration (indices, models, pipelines) to AWS.
-- Configure AWS-specific settings (IAM roles, security, network access).
+- Call `prepare_aws_deployment()` to get the deployment context. This returns:
+  - `deployment_target`: "serverless" or "domain" (determined automatically from search strategy)
+  - `search_strategy`: the detected strategy (bm25, neural_sparse, dense_vector, hybrid, agentic)
+  - `steering_files`: ordered list of steering files to follow
+  - `local_config`: extracted configuration from local setup (text fields, sample doc, preferences)
+  - `required_mcp_servers`: MCP servers that must be connected
+  - `state_file_template`: JSON template for `.opensearch-deploy-state.json`
+- Write the `state_file_template` to `.opensearch-deploy-state.json` in the project root.
+- Verify all `required_mcp_servers` are connected before proceeding.
+- Follow each steering file from `steering_files` in order:
+  - **Serverless track**: `serverless-01-provision.md` → `serverless-02-deploy-search.md`
+  - **Domain track**: `domain-01-provision.md` → `domain-02-deploy-search.md` → `domain-03-agentic-setup.md` (agentic only)
+- Between each steering file, read `.opensearch-deploy-state.json` for accumulated state (ARNs, IDs, endpoints).
+- After each major step, update `.opensearch-deploy-state.json` with new values as instructed by the steering file.
+- For cost, security, or HA questions, refer to `aws-reference.md`.
 - Provide the user with AWS endpoint URLs and access instructions.
 
 ### Post-Execution
@@ -298,6 +303,7 @@ This power provides an OpenSearch Search Solution building workflow. It collects
 | `execute_plan` | 4 | Execute the plan (create index, models, pipelines, UI) |
 | `set_execution_from_execution_report` | 4 | Parse/store finalized worker output for manual execution mode |
 | `retry_execution` | 4 | Resume from a failed execution step |
+| `prepare_aws_deployment` | 5 | Get deployment target, local config, steering file list, and state template for AWS deployment |
 | `cleanup` | Post | Remove test documents on user request |
 
 ### Knowledge Tools

--- a/kiro/opensearch-search-builder/steering/aws-opensearch-serverless.md
+++ b/kiro/opensearch-search-builder/steering/aws-opensearch-serverless.md
@@ -84,7 +84,7 @@ POST /opensearchserverless/CreateAccessPolicy
 {
   "name": "<collection-name>-data-policy",
   "type": "data",
-  "policy": "[{\"Rules\":[{\"ResourceType\":\"index\",\"Resource\":[\"index/<collection-name>/*\"],\"Permission\":[\"aoss:CreateIndex\",\"aoss:DescribeIndex\",\"aoss:UpdateIndex\",\"aoss:DeleteIndex\",\"aoss:ReadDocument\",\"aoss:WriteDocument\"]},{\"ResourceType\":\"collection\",\"Resource\":[\"collection/<collection-name>\"],\"Permission\":[\"aoss:CreateCollectionItems\",\"aoss:DescribeCollectionItems\"]},{\"ResourceType\":\"model\",\"Resource\":[\"model/<collection-name>/*\"],\"Permission\":[\"aoss:CreateMLResource\"]}],\"Principal\":[\"arn:aws:iam::<account-id>:role/<role-name>\"]}]"
+  "policy": "[{\"Rules\":[{\"ResourceType\":\"index\",\"Resource\":[\"index/<collection-name>/*\"],\"Permission\":[\"aoss:CreateIndex\",\"aoss:DescribeIndex\",\"aoss:UpdateIndex\",\"aoss:DeleteIndex\",\"aoss:ReadDocument\",\"aoss:WriteDocument\"]},{\"ResourceType\":\"collection\",\"Resource\":[\"collection/<collection-name>\"],\"Permission\":[\"aoss:CreateCollectionItems\",\"aoss:DescribeCollectionItems\"]},{\"ResourceType\":\"model\",\"Resource\":[\"model/<collection-name>/*\"],\"Permission\":[\"aoss:*\"]}],\"Principal\":[\"arn:aws:iam::<account-id>:role/<role-name>\"]}]"
 }
 ```
 

--- a/kiro/opensearch-search-builder/steering/aws/aws-reference.md
+++ b/kiro/opensearch-search-builder/steering/aws/aws-reference.md
@@ -1,0 +1,59 @@
+---
+title: "AWS OpenSearch Deployment Reference"
+inclusion: manual
+---
+
+# AWS OpenSearch Deployment Reference
+
+Reference material for cost, security, and operations. Load only when the user asks about these topics.
+
+## Cost: OpenSearch Serverless
+
+- Charged per OCU (OpenSearch Compute Units) hour
+- Minimum: 2 OCUs for indexing, 2 OCUs for search
+- Scales automatically based on workload
+- Storage charged separately per GB
+- Neural sparse enrichment: charged based on SemanticSearchOCU CloudWatch metric
+
+## Cost: OpenSearch Domain
+
+- Instance hours (varies by instance type)
+- EBS storage (GB-month)
+- Data transfer and snapshot storage
+
+Typical small production cluster:
+- 3x r6g.large.search: ~$400-500/month
+- 300GB EBS storage: ~$30/month
+
+Cost optimization: reserved instances (up to 30% savings), right-sizing, UltraWarm for cold data.
+
+## Security Best Practices
+
+1. **Network**: Deploy in VPC for production, use security groups, enable VPC Flow Logs
+2. **Access**: Enable fine-grained access control, use IAM roles, least-privilege policies
+3. **Encryption**: At-rest encryption, node-to-node encryption, enforce HTTPS
+4. **Monitoring**: Enable CloudWatch logs, set up security alerting
+
+## High Availability (Domain)
+
+1. Enable zone awareness, distribute across 3 AZs
+2. Enable automated snapshots to S3
+3. Configure standby replicas
+4. Test restore procedures
+
+## Monitoring
+
+1. CloudWatch logs: index slow logs, search slow logs, error logs, audit logs
+2. CloudWatch alarms: cluster health, CPU/memory, storage, JVM pressure
+3. SNS notifications for alerts
+
+## Troubleshooting
+
+| Issue | Check |
+|---|---|
+| Domain creation fails | Service quotas, VPC config, IAM permissions |
+| Cluster health yellow/red | Shard allocation, storage space, node health |
+| Access denied | Fine-grained access control, IAM policies, data access policies |
+| Model deployment fails | ML plugin enabled, memory allocation, Bedrock region availability |
+| Slow queries | Slow logs, query optimization, resource utilization |
+| Collection creation fails | Service quotas, region availability, encryption policy |

--- a/kiro/opensearch-search-builder/steering/aws/domain-01-provision.md
+++ b/kiro/opensearch-search-builder/steering/aws/domain-01-provision.md
@@ -1,0 +1,90 @@
+---
+title: "AWS OpenSearch Domain - Step 1: Provision Domain"
+inclusion: manual
+---
+
+# Provision OpenSearch Domain
+
+This guide covers creating and configuring an AWS OpenSearch Domain (managed cluster). Follow it after `prepare_aws_deployment()` returns `deployment_target: "domain"`.
+
+## Prerequisites
+
+Before starting:
+1. Read `.opensearch-deploy-state.json` for current deployment state
+2. Confirm AWS credentials are valid: `aws sts get-caller-identity` (via AWS API MCP)
+3. Verify required MCP servers are connected: `awslabs.aws-api-mcp-server`, `opensearch-mcp-server`
+4. Save the AWS account ID and principal ARN to the state file
+
+## State Input
+
+From `.opensearch-deploy-state.json`:
+- `deployment_target`: "domain"
+- `search_strategy`: "agentic" or other
+
+## Step 1: Create Domain
+
+Use the AWS API MCP server:
+
+```
+aws opensearch create-domain
+  --domain-name <domain-name>
+  --engine-version OpenSearch_2.11
+  --cluster-config InstanceType=t3.medium.search,InstanceCount=1
+  --ebs-options EBSEnabled=true,VolumeType=gp3,VolumeSize=100
+  --node-to-node-encryption-options Enabled=true
+  --encryption-at-rest-options Enabled=true
+  --domain-endpoint-options EnforceHTTPS=true
+```
+
+For production, use larger instances (r6g.large.search, 3+ data nodes, 3 dedicated masters).
+
+## Step 2: Enable Fine-Grained Access Control
+
+```
+aws opensearch update-domain-config
+  --domain-name <domain-name>
+  --advanced-security-options Enabled=true,InternalUserDatabaseEnabled=true,MasterUserOptions={MasterUserName=admin,MasterUserPassword=<strong-password>}
+```
+
+Set up:
+- Master user credentials
+- Role-based access control
+
+## Step 3: Configure Network Access
+
+**Public access (development):**
+- Set IP-based access policies
+- Use fine-grained access control
+
+**VPC access (production):**
+- Deploy within VPC, configure security groups
+
+## Step 4: Wait for Domain Active
+
+Poll until domain is active (typically 10-15 minutes):
+
+```
+aws opensearch describe-domain --domain-name <domain-name>
+```
+
+Wait for:
+- `Processing`: false
+- `DomainStatus.Endpoint`: available
+
+## State Output
+
+Update `.opensearch-deploy-state.json`:
+```json
+{
+  "step_completed": "provision-domain",
+  "aws_account_id": "<from sts get-caller-identity>",
+  "aws_region": "<configured region>",
+  "principal_arn": "<from sts get-caller-identity>",
+  "resource_name": "<domain-name>",
+  "resource_endpoint": "<domain-endpoint-url>"
+}
+```
+
+## Next Step
+
+Proceed to `domain-02-deploy-search.md`.

--- a/kiro/opensearch-search-builder/steering/aws/domain-02-deploy-search.md
+++ b/kiro/opensearch-search-builder/steering/aws/domain-02-deploy-search.md
@@ -1,0 +1,140 @@
+---
+title: "AWS OpenSearch Domain - Step 2: Deploy Search Configuration"
+inclusion: manual
+---
+
+# Deploy Search Configuration to Domain
+
+This guide covers migrating index configuration, deploying ML models, and creating pipelines on the OpenSearch domain.
+
+## State Input
+
+From `.opensearch-deploy-state.json`:
+- `resource_endpoint`: domain endpoint URL
+- `search_strategy`: determines which components to deploy
+
+From `prepare_aws_deployment()` output:
+- `local_config.text_fields`: fields to configure
+- `plan_summary.solution`: full architecture plan
+
+## Step 1: Migrate Index Configuration
+
+Using opensearch-mcp-server:
+
+1. Create the index on the domain endpoint with mappings from the local setup
+2. Include all field mappings, settings, and analyzers
+3. Configure replicas for high availability (1-2 replicas)
+
+```
+PUT <domain-endpoint>/<index-name>
+{
+  "settings": { ... from local config ... },
+  "mappings": { ... from local config ... }
+}
+```
+
+Update state: `"index_name": "<index-name>"`
+
+## Step 2: Deploy ML Models (if semantic/hybrid search)
+
+For search strategies that use embeddings (dense vector, hybrid, neural sparse):
+
+### Deploy pretrained models from OpenSearch model repository:
+
+```
+POST <domain-endpoint>/_plugins/_ml/models/_register?deploy=true
+{
+  "name": "huggingface/sentence-transformers/all-MiniLM-L12-v2",
+  "version": "1.0.1",
+  "model_format": "TORCH_SCRIPT"
+}
+```
+
+Or deploy remote Bedrock models (see `domain-03-agentic-setup.md` Step 1-2 for IAM role and connector setup pattern).
+
+Test model inference:
+```
+POST <domain-endpoint>/_plugins/_ml/models/<model-id>/_predict
+{
+  "parameters": { "inputText": "hello world" }
+}
+```
+
+Update state: `"model_id": "<model_id>"`
+
+## Step 3: Create Ingest Pipelines
+
+Recreate ingest pipelines from local setup:
+
+```
+PUT <domain-endpoint>/_ingest/pipeline/<pipeline-name>
+{
+  "description": "Embedding pipeline",
+  "processors": [{
+    "text_embedding": {
+      "model_id": "<model_id>",
+      "field_map": { "<text-field>": "<vector-field>" }
+    }
+  }]
+}
+```
+
+Attach pipeline to index:
+```
+PUT <domain-endpoint>/<index-name>/_settings
+{ "index.default_pipeline": "<pipeline-name>" }
+```
+
+Update state: `"ingest_pipeline_name": "<pipeline-name>"`
+
+## Step 4: Create Search Pipelines (if applicable)
+
+For hybrid search, create normalization pipeline:
+
+```
+PUT <domain-endpoint>/_search/pipeline/<search-pipeline-name>
+{
+  "phase_results_processors": [{
+    "normalization-processor": {
+      "normalization": { "technique": "min_max" },
+      "combination": { "technique": "arithmetic_mean", "parameters": { "weights": [0.3, 0.7] } }
+    }
+  }]
+}
+```
+
+Update state: `"search_pipeline_name": "<search-pipeline-name>"`
+
+## Step 5: Index Sample Documents
+
+1. Use the same sample documents from Phase 1
+2. Index test documents to verify the setup
+3. Test search queries appropriate to the strategy
+4. Verify embeddings and pipeline processing
+
+## State Output
+
+Update `.opensearch-deploy-state.json`:
+```json
+{
+  "step_completed": "deploy-search",
+  "index_name": "<index-name>",
+  "model_id": "<if created>",
+  "ingest_pipeline_name": "<if created>",
+  "search_pipeline_name": "<if created>"
+}
+```
+
+## Next Step
+
+- **For agentic search**: Proceed to `domain-03-agentic-setup.md`
+- **For all other strategies**: Deployment complete. Provide access information to user.
+
+### Access Information (non-agentic)
+
+Give the user:
+- Domain endpoint URL
+- Domain ARN
+- OpenSearch Dashboards URL
+- Master user credentials (securely)
+- Sample search queries

--- a/kiro/opensearch-search-builder/steering/aws/domain-03-agentic-setup.md
+++ b/kiro/opensearch-search-builder/steering/aws/domain-03-agentic-setup.md
@@ -1,0 +1,198 @@
+---
+title: "AWS OpenSearch Domain - Step 3: Configure Agentic Search"
+inclusion: manual
+---
+
+# Configure Agentic Search on Domain
+
+This guide configures conversational agents with QueryPlanningTool for natural language search. Only follow this for agentic search strategy.
+
+Agentic search requires OpenSearch 2.11+ and uses Bedrock Claude as the reasoning model.
+
+## State Input
+
+From `.opensearch-deploy-state.json`:
+- `resource_endpoint`: domain endpoint URL
+- `index_name`: target index
+- `aws_region`: for Bedrock endpoint
+- `aws_account_id`: for IAM role ARN
+
+## Step 1: Create IAM Role for Bedrock Access
+
+```json
+POST /iam/CreateRole
+{
+  "RoleName": "opensearch-bedrock-agent-role",
+  "AssumeRolePolicyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": { "Service": "opensearchservice.amazonaws.com" },
+      "Action": "sts:AssumeRole"
+    }]
+  }
+}
+```
+
+Attach Bedrock invoke permissions:
+
+```json
+POST /iam/PutRolePolicy
+{
+  "RoleName": "opensearch-bedrock-agent-role",
+  "PolicyName": "BedrockClaudeInvokePolicy",
+  "PolicyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": "bedrock:InvokeModel",
+      "Resource": "arn:aws:bedrock:*::foundation-model/anthropic.claude-3-5-sonnet-*"
+    }]
+  }
+}
+```
+
+Update state: `"iam_role_arn": "<role-arn>"`
+
+## Step 2: Map ML Role (if fine-grained access control enabled)
+
+1. Log in to OpenSearch Dashboards
+2. Navigate to Security > Roles > `ml_full_access`
+3. Mapped users > Manage mapping
+4. Add IAM role ARN under Backend roles: `arn:aws:iam::<aws_account_id>:role/opensearch-bedrock-agent-role`
+5. Click Map
+
+## Step 3: Create Bedrock Claude Connector
+
+```
+POST <domain-endpoint>/_plugins/_ml/connectors/_create
+{
+  "name": "Amazon Bedrock Claude 3.5 Sonnet",
+  "description": "Connector for Bedrock Claude for agentic search",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "credential": { "roleArn": "<iam_role_arn>" },
+  "parameters": {
+    "region": "<aws_region>",
+    "service_name": "bedrock",
+    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "system_prompt": "You are a helpful assistant that plans and executes search queries.",
+    "temperature": 0.0,
+    "top_p": 0.9,
+    "max_tokens": 2000
+  },
+  "actions": [{
+    "action_type": "predict",
+    "method": "POST",
+    "headers": { "content-type": "application/json" },
+    "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
+    "request_body": "{ \"system\": [{\"text\": \"${parameters.system_prompt}\"}], \"messages\": ${parameters.messages}, \"inferenceConfig\": {\"temperature\": ${parameters.temperature}, \"topP\": ${parameters.top_p}, \"maxTokens\": ${parameters.max_tokens}} }"
+  }]
+}
+```
+
+Update state: `"connector_id": "<connector_id>"`
+
+## Step 4: Register and Deploy Model
+
+```
+POST <domain-endpoint>/_plugins/_ml/models/_register?deploy=true
+{
+  "name": "Bedrock Claude 3.5 Sonnet for Agentic Search",
+  "function_name": "remote",
+  "description": "Claude model for query planning and reasoning",
+  "connector_id": "<connector_id>"
+}
+```
+
+Test the model:
+```
+POST <domain-endpoint>/_plugins/_ml/models/<model-id>/_predict
+{
+  "parameters": {
+    "messages": [{ "role": "user", "content": [{ "text": "hello" }] }]
+  }
+}
+```
+
+Verify the response contains generated text.
+
+Update state: `"model_id": "<model_id>"`
+
+## Step 5: Create Conversational Agent
+
+```
+POST <domain-endpoint>/_plugins/_ml/agents/_register
+{
+  "name": "Agentic Search Agent",
+  "type": "conversational",
+  "description": "Agent for natural language search with query planning",
+  "llm": {
+    "model_id": "<model_id>",
+    "parameters": { "max_iteration": 15 }
+  },
+  "memory": { "type": "conversation_index" },
+  "parameters": { "_llm_interface": "bedrock/converse" },
+  "tools": [{ "type": "QueryPlanningTool" }],
+  "app_type": "os_chat"
+}
+```
+
+Update state: `"agent_id": "<agent_id>"`
+
+## Step 6: Create Agentic Search Pipeline
+
+```
+PUT <domain-endpoint>/_search/pipeline/agentic-search-pipeline
+{
+  "request_processors": [{
+    "agentic_query_translator": { "agent_id": "<agent_id>" }
+  }]
+}
+```
+
+Update state: `"search_pipeline_name": "agentic-search-pipeline"`
+
+## Step 7: Test Agentic Search
+
+```
+GET <domain-endpoint>/<index-name>/_search?search_pipeline=agentic-search-pipeline
+{
+  "query": {
+    "agentic": {
+      "query_text": "Find all documents about machine learning published in the last year",
+      "query_fields": ["title", "content", "publish_date"]
+    }
+  }
+}
+```
+
+The agent will:
+1. Analyze the natural language question
+2. Examine the index mapping
+3. Generate appropriate OpenSearch DSL query
+4. Execute the query and return results
+
+## State Output
+
+Final `.opensearch-deploy-state.json`:
+```json
+{
+  "step_completed": "agentic-setup",
+  "iam_role_arn": "<role-arn>",
+  "connector_id": "<connector-id>",
+  "model_id": "<model-id>",
+  "agent_id": "<agent-id>",
+  "search_pipeline_name": "agentic-search-pipeline"
+}
+```
+
+## Provide Access Information
+
+Give the user:
+- Domain endpoint URL
+- Domain ARN
+- OpenSearch Dashboards URL
+- Master user credentials (securely)
+- Sample agentic search queries
+- Agent ID for direct agent invocation

--- a/kiro/opensearch-search-builder/steering/aws/serverless-01-provision.md
+++ b/kiro/opensearch-search-builder/steering/aws/serverless-01-provision.md
@@ -1,0 +1,109 @@
+---
+title: "AWS OpenSearch Serverless - Step 1: Provision Collection"
+inclusion: manual
+---
+
+# Provision OpenSearch Serverless Collection
+
+This guide covers creating and configuring an OpenSearch Serverless collection. Follow it after `prepare_aws_deployment()` returns `deployment_target: "serverless"`.
+
+## Prerequisites
+
+Before starting:
+1. Read `.opensearch-deploy-state.json` for current deployment state
+2. Confirm AWS credentials are valid: `aws sts get-caller-identity` (via AWS API MCP)
+3. Verify required MCP servers are connected: `awslabs.aws-api-mcp-server`, `opensearch-mcp-server`
+4. Save the AWS account ID and principal ARN to the state file
+
+## State Input
+
+From `.opensearch-deploy-state.json`:
+- `deployment_target`: "serverless"
+- `search_strategy`: determines collection type
+
+## Step 1: Create Encryption Policy
+
+Create an encryption policy (required before collection creation):
+
+```json
+POST /opensearchserverless/CreateSecurityPolicy
+{
+  "name": "<collection-name>-encryption",
+  "type": "encryption",
+  "policy": "{\"Rules\":[{\"ResourceType\":\"collection\",\"Resource\":[\"collection/<collection-name>\"]}],\"AWSOwnedKey\":true}"
+}
+```
+
+## Step 2: Create Network Policy
+
+```json
+POST /opensearchserverless/CreateSecurityPolicy
+{
+  "name": "<collection-name>-network",
+  "type": "network",
+  "policy": "[{\"Rules\":[{\"ResourceType\":\"collection\",\"Resource\":[\"collection/<collection-name>\"]},{\"ResourceType\":\"dashboard\",\"Resource\":[\"collection/<collection-name>\"]}],\"AllowFromPublic\":true}]"
+}
+```
+
+For production, replace `AllowFromPublic` with VPC endpoint IDs.
+
+## Step 3: Create Data Access Policy
+
+Create a data access policy with permissions for index, collection, and ML resources:
+
+```json
+POST /opensearchserverless/CreateAccessPolicy
+{
+  "name": "<collection-name>-data",
+  "type": "data",
+  "policy": "[{\"Rules\":[{\"ResourceType\":\"index\",\"Resource\":[\"index/<collection-name>/*\"],\"Permission\":[\"aoss:CreateIndex\",\"aoss:DescribeIndex\",\"aoss:UpdateIndex\",\"aoss:DeleteIndex\",\"aoss:ReadDocument\",\"aoss:WriteDocument\"]},{\"ResourceType\":\"collection\",\"Resource\":[\"collection/<collection-name>\"],\"Permission\":[\"aoss:CreateCollectionItems\",\"aoss:DescribeCollectionItems\"]},{\"ResourceType\":\"model\",\"Resource\":[\"model/<collection-name>/*\"],\"Permission\":[\"aoss:CreateMLResource\"]}],\"Principal\":[\"<principal_arn>\"]}]"
+}
+```
+
+Replace `<principal_arn>` with the value from the state file.
+
+## Step 4: Create Collection
+
+Choose collection type based on search strategy:
+- **VECTORSEARCH**: For dense vector search (semantic search with dense embeddings)
+- **SEARCH**: For all other strategies (BM25, neural sparse, hybrid with neural sparse)
+
+Neural sparse (automatic semantic enrichment) requires SEARCH type, not VECTORSEARCH.
+
+```json
+POST /opensearchserverless/CreateCollection
+{
+  "name": "<collection-name>",
+  "type": "SEARCH or VECTORSEARCH",
+  "description": "Search application deployed from local OpenSearch"
+}
+```
+
+## Step 5: Wait for Collection Active
+
+Poll until status is "ACTIVE" (typically 1-3 minutes):
+
+```json
+POST /opensearchserverless/BatchGetCollection
+{
+  "names": ["<collection-name>"]
+}
+```
+
+## State Output
+
+Update `.opensearch-deploy-state.json`:
+```json
+{
+  "step_completed": "provision-collection",
+  "aws_account_id": "<from sts get-caller-identity>",
+  "aws_region": "<configured region>",
+  "principal_arn": "<from sts get-caller-identity>",
+  "resource_name": "<collection-name>",
+  "resource_endpoint": "<collection-endpoint-url>"
+}
+```
+
+## Next Step
+
+Proceed to `serverless-02-deploy-search.md`.

--- a/kiro/opensearch-search-builder/steering/aws/serverless-02-deploy-search.md
+++ b/kiro/opensearch-search-builder/steering/aws/serverless-02-deploy-search.md
@@ -1,0 +1,283 @@
+---
+title: "AWS OpenSearch Serverless - Step 2: Deploy Search Configuration"
+inclusion: manual
+---
+
+# Deploy Search Configuration to Serverless
+
+This guide covers creating indices, deploying ML models, and configuring pipelines on the serverless collection.
+
+## State Input
+
+From `.opensearch-deploy-state.json`:
+- `resource_endpoint`: collection endpoint URL
+- `search_strategy`: determines which path to follow
+- `principal_arn`: for IAM role creation (dense vector path)
+
+From `prepare_aws_deployment()` output:
+- `local_config.text_fields`: fields to configure for search
+- `plan_summary.solution`: full architecture plan
+
+## Route by Strategy
+
+- **Neural Sparse** → follow "Neural Sparse Path" below
+- **Dense Vector or Hybrid** → follow "Dense Vector Path" below
+- **BM25** → follow "BM25 Path" below
+
+---
+
+## Neural Sparse Path (Automatic Semantic Enrichment)
+
+### Create Index with Semantic Enrichment
+
+Use AWS API MCP to create the index with automatic enrichment:
+
+```json
+POST /opensearchserverless/CreateIndex
+{
+  "id": "<collection-id>",
+  "indexName": "<index-name>",
+  "indexSchema": {
+    "mappings": {
+      "properties": {
+        "<text-field>": {
+          "type": "text",
+          "semantic_enrichment": {
+            "status": "ENABLED",
+            "language_options": "english"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Key points:
+- Set `semantic_enrichment.status` to "ENABLED" on text fields for neural sparse
+- `language_options`: "english" or "multi-lingual"
+- System automatically deploys sparse model, creates ingest/search pipelines
+- Standard "match" queries are automatically rewritten to neural sparse queries
+- No manual model or pipeline management required
+
+Update state: `"index_name": "<index-name>"`, `"step_completed": "deploy-search"`
+
+Skip to "Index Sample Documents" below.
+
+---
+
+## Dense Vector Path
+
+### Step 1: Create IAM Role for Bedrock
+
+```json
+POST /iam/CreateRole
+{
+  "RoleName": "opensearch-bedrock-role",
+  "AssumeRolePolicyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": { "Service": "ml.opensearchservice.amazonaws.com" },
+      "Action": "sts:AssumeRole"
+    }]
+  }
+}
+```
+
+Attach Bedrock invoke permissions:
+
+```json
+POST /iam/PutRolePolicy
+{
+  "RoleName": "opensearch-bedrock-role",
+  "PolicyName": "BedrockInvokePolicy",
+  "PolicyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": "bedrock:InvokeModel",
+      "Resource": "arn:aws:bedrock:*::foundation-model/amazon.titan-embed-text-v2:0"
+    }]
+  }
+}
+```
+
+Update state: `"iam_role_arn": "<role-arn>"`
+
+### Step 2: Create ML Connector
+
+Use opensearch-mcp-server to create a Bedrock Titan connector:
+
+```
+POST <collection-endpoint>/_plugins/_ml/connectors/_create
+{
+  "name": "Amazon Bedrock Titan Embedding V2",
+  "description": "Connector to Bedrock Titan embedding model",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "parameters": {
+    "region": "<aws-region>",
+    "service_name": "bedrock"
+  },
+  "credential": {
+    "roleArn": "<iam_role_arn>"
+  },
+  "actions": [{
+    "action_type": "predict",
+    "method": "POST",
+    "url": "https://bedrock-runtime.<aws-region>.amazonaws.com/model/amazon.titan-embed-text-v2:0/invoke",
+    "headers": { "content-type": "application/json", "x-amz-content-sha256": "required" },
+    "request_body": "{ \"inputText\": \"${parameters.inputText}\" }",
+    "pre_process_function": "\n    StringBuilder builder = new StringBuilder();\n    builder.append(\"\\\"\");\n    String first = params.text_docs[0];\n    builder.append(first);\n    builder.append(\"\\\"\");\n    def parameters = \"{\" +\"\\\"inputText\\\":\" + builder + \"}\";\n    return  \"{\" +\"\\\"parameters\\\":\" + parameters + \"}\";",
+    "post_process_function": "\n      def name = \"sentence_embedding\";\n      def dataType = \"FLOAT32\";\n      if (params.embedding == null || params.embedding.length == 0) {\n        return params.message;\n      }\n      def shape = [params.embedding.length];\n      def json = \"{\" +\n                 \"\\\"name\\\":\\\"\" + name + \"\\\",\" +\n                 \"\\\"data_type\\\":\\\"\" + dataType + \"\\\",\" +\n                 \"\\\"shape\\\":\" + shape + \",\" +\n                 \"\\\"data\\\":\" + params.embedding +\n                 \"}\";\n      return json;\n    "
+  }]
+}
+```
+
+Update state: `"connector_id": "<connector_id>"`
+
+### Step 3: Register and Deploy Model
+
+```
+POST <collection-endpoint>/_plugins/_ml/model_groups/_register
+{ "name": "bedrock_embedding_models", "description": "Bedrock embedding model group" }
+```
+
+Update state: `"model_group_id": "<model_group_id>"`
+
+```
+POST <collection-endpoint>/_plugins/_ml/models/_register
+{
+  "name": "bedrock-titan-embed-v2",
+  "function_name": "remote",
+  "description": "Bedrock Titan Text Embeddings V2",
+  "model_group_id": "<model_group_id>",
+  "connector_id": "<connector_id>"
+}
+```
+
+```
+POST <collection-endpoint>/_plugins/_ml/models/<model-id>/_deploy
+```
+
+Test: `POST <collection-endpoint>/_plugins/_ml/models/<model-id>/_predict` with `{"parameters": {"inputText": "hello world"}}`. Verify 1024-dimensional embeddings.
+
+Update state: `"model_id": "<model_id>"`
+
+### Step 4: Create Ingest Pipeline
+
+```
+PUT <collection-endpoint>/_ingest/pipeline/bedrock-embedding-pipeline
+{
+  "description": "Bedrock Titan embedding pipeline",
+  "processors": [{
+    "text_embedding": {
+      "model_id": "<model_id>",
+      "field_map": { "<text-field>": "<vector-field>" }
+    }
+  }]
+}
+```
+
+Update state: `"ingest_pipeline_name": "bedrock-embedding-pipeline"`
+
+### Step 5: Create Index
+
+```
+PUT <collection-endpoint>/<index-name>
+{
+  "settings": {
+    "index": { "knn": true, "knn.space_type": "cosinesimil", "default_pipeline": "bedrock-embedding-pipeline" }
+  },
+  "mappings": {
+    "properties": {
+      "<text-field>": { "type": "text" },
+      "<vector-field>": {
+        "type": "knn_vector",
+        "dimension": 1024,
+        "method": { "name": "hnsw", "space_type": "cosinesimil", "engine": "faiss" }
+      }
+    }
+  }
+}
+```
+
+Update state: `"index_name": "<index-name>"`
+
+### Step 6: Create Search Pipeline (hybrid search only)
+
+If search strategy is "hybrid":
+
+```
+PUT <collection-endpoint>/_search/pipeline/hybrid-search-pipeline
+{
+  "description": "Hybrid search with normalization",
+  "phase_results_processors": [{
+    "normalization-processor": {
+      "normalization": { "technique": "min_max" },
+      "combination": { "technique": "arithmetic_mean", "parameters": { "weights": [0.3, 0.7] } }
+    }
+  }]
+}
+```
+
+Update state: `"search_pipeline_name": "hybrid-search-pipeline"`, `"step_completed": "deploy-search"`
+
+---
+
+## BM25 Path
+
+### Create Index
+
+Use opensearch-mcp-server to create the index with text mappings from local config:
+
+```
+PUT <collection-endpoint>/<index-name>
+{
+  "mappings": {
+    "properties": {
+      "<text-field>": { "type": "text" }
+    }
+  }
+}
+```
+
+Include all field mappings from the local setup.
+
+Update state: `"index_name": "<index-name>"`, `"step_completed": "deploy-search"`
+
+---
+
+## Index Sample Documents
+
+After index creation (all paths):
+1. Use the same sample documents from Phase 1
+2. Index a few test documents to verify the setup
+3. Test search queries:
+   - Neural Sparse: use standard `match` queries (automatically rewritten)
+   - Dense Vector: use `neural` query with `model_id`
+   - BM25: use standard `match` queries
+
+## Provide Access Information
+
+Give the user:
+- Collection endpoint URL
+- Collection ARN
+- Dashboard URL (if applicable)
+- Sample search queries to test
+
+## State Output
+
+Final state update:
+```json
+{
+  "step_completed": "deploy-search",
+  "index_name": "<index-name>",
+  "iam_role_arn": "<if created>",
+  "connector_id": "<if created>",
+  "model_id": "<if created>",
+  "ingest_pipeline_name": "<if created>",
+  "search_pipeline_name": "<if created>"
+}
+```

--- a/opensearch_orchestrator/mcp_server.py
+++ b/opensearch_orchestrator/mcp_server.py
@@ -1478,6 +1478,21 @@ def set_search_ui_suggestions(index_name: str, suggestion_meta_json: str) -> str
 
 
 @mcp.tool()
+def prepare_aws_deployment() -> dict:
+    """Prepare structured context for deploying the local search strategy to AWS OpenSearch.
+    Call after successful Phase 4 execution.
+
+    Returns deployment target (serverless or domain), search strategy, local configuration,
+    list of steering files to follow in order, required MCP servers, and a state file
+    template for tracking deployment progress.
+    """
+    result = _engine.prepare_aws_deployment()
+    if "error" not in result:
+        _persist_engine_state("prepare_aws_deployment")
+    return result
+
+
+@mcp.tool()
 def cleanup() -> str:
     """Remove verification/test documents from the OpenSearch index.
     Call only when the user explicitly asks for cleanup.

--- a/opensearch_orchestrator/orchestrator_engine.py
+++ b/opensearch_orchestrator/orchestrator_engine.py
@@ -449,6 +449,108 @@ class OrchestratorEngine:
         self.phase = Phase.DONE if latest_status == "success" else Phase.EXEC_FAILED
         return {"execution_report": worker_result}
 
+    def prepare_aws_deployment(self) -> dict[str, object]:
+        """Build structured context for AWS deployment (Phase 5).
+
+        Returns deployment target, search strategy, local config extracted
+        from the finalized plan and session state.
+        """
+        if self.phase != Phase.DONE:
+            return {
+                "error": (
+                    "AWS deployment requires successful local execution (Phase 4). "
+                    "Current phase: " + str(getattr(self.phase, "name", self.phase))
+                )
+            }
+        if self.plan_result is None:
+            return {"error": "No finalized plan available."}
+
+        solution = str(self.plan_result.get("solution", "")).lower()
+        capabilities = str(self.plan_result.get("search_capabilities", ""))
+        keynote = str(self.plan_result.get("keynote", ""))
+
+        # Detect primary search strategy from the solution text.
+        strategy = "bm25"
+        if "agentic" in solution:
+            strategy = "agentic"
+        elif "hybrid" in solution:
+            strategy = "hybrid"
+        elif "neural sparse" in solution or "sparse_encoding" in solution:
+            strategy = "neural_sparse"
+        elif (
+            "dense vector" in solution
+            or "knn" in solution
+            or "hnsw" in solution
+            or "text_embedding" in solution
+        ):
+            strategy = "dense_vector"
+
+        # Deployment target: agentic requires domain, everything else uses serverless.
+        deployment_target = "domain" if strategy == "agentic" else "serverless"
+
+        state = self.state
+        sample_doc = None
+        if state.sample_doc_json:
+            try:
+                sample_doc = json.loads(state.sample_doc_json)
+            except (json.JSONDecodeError, TypeError):
+                sample_doc = None
+
+        text_fields = list(state.inferred_semantic_text_fields or [])
+
+        return {
+            "deployment_target": deployment_target,
+            "search_strategy": strategy,
+            "steering_files": (
+                [
+                    "steering/aws/domain-01-provision.md",
+                    "steering/aws/domain-02-deploy-search.md",
+                    "steering/aws/domain-03-agentic-setup.md",
+                ]
+                if deployment_target == "domain"
+                else [
+                    "steering/aws/serverless-01-provision.md",
+                    "steering/aws/serverless-02-deploy-search.md",
+                ]
+            ),
+            "local_config": {
+                "text_fields": text_fields,
+                "sample_doc": sample_doc,
+                "budget": state.budget_preference,
+                "performance": state.performance_priority,
+                "deployment_preference": state.model_deployment_preference,
+                "hybrid_weight_profile": state.hybrid_weight_profile,
+            },
+            "plan_summary": {
+                "solution": str(self.plan_result.get("solution", "")),
+                "search_capabilities": capabilities,
+                "keynote": keynote,
+            },
+            "required_mcp_servers": [
+                "awslabs.aws-api-mcp-server",
+                "opensearch-mcp-server",
+                "aws-docs",
+            ],
+            "state_file_template": {
+                "deployment_target": deployment_target,
+                "search_strategy": strategy,
+                "step_completed": None,
+                "aws_account_id": None,
+                "aws_region": None,
+                "principal_arn": None,
+                "resource_name": None,
+                "resource_endpoint": None,
+                "iam_role_arn": None,
+                "connector_id": None,
+                "model_id": None,
+                "model_group_id": None,
+                "agent_id": None,
+                "index_name": None,
+                "ingest_pipeline_name": None,
+                "search_pipeline_name": None,
+            },
+        }
+
     def build_retry_execution_context(self) -> dict[str, object]:
         """Build retry execution context without running the worker."""
         worker_state = self._get_last_worker_run_state()

--- a/tests/test_mcp_advanced_tool_gate.py
+++ b/tests/test_mcp_advanced_tool_gate.py
@@ -38,6 +38,7 @@ def test_default_tool_surface_is_workflow_only() -> None:
         "finalize_plan",
         "launch_search_ui",
         "load_sample",
+        "prepare_aws_deployment",
         "read_agentic_search_guide",
         "read_dense_vector_models",
         "read_knowledge_base",


### PR DESCRIPTION
 Improve Phase 5 (AWS deployment) reliability by:
  - Adding a prepare_aws_deployment() MCP tool that deterministically
    routes to the correct steering files for AOS or AOSS ,
    extracts local config, and returns a state file template
  - Splitting monolithic steering files (545 and 436 lines) into
    6 focused files (59-283 lines each), all under the 500-line
    recommended limit suggested by Claude Code and Cursor
  - Introducing .opensearch-deploy-state.json for tracking ARNs, IDs,
    and endpoints between deployment steps
  - Updating POWER.md Phase 5 to use tool-driven routing instead of
    LLM-interpreted file selection