### PR TITLE
Agentic search template

### DIFF
--- a/opensearch_orchestrator/opensearch_ops_tools.py
+++ b/opensearch_orchestrator/opensearch_ops_tools.py
@@ -694,6 +694,7 @@ def _build_client(use_ssl: bool, http_auth: tuple[str, str] | None = None) -> Op
         "use_ssl": use_ssl,
         "verify_certs": False,
         "ssl_show_warn": False,
+        "timeout": 60,
     }
     if http_auth is not None:
         kwargs["http_auth"] = http_auth
@@ -4730,6 +4731,8 @@ def _resolve_semantic_runtime_hints(
         search_pipeline = ""
 
     # Check if search pipeline is agentic
+    agentic_model_id = ""
+    agentic_agent_type = ""
     if search_pipeline:
         try:
             pipeline_response = opensearch_client.transport.perform_request("GET", f"/_search/pipeline/{search_pipeline}")
@@ -4738,6 +4741,22 @@ def _resolve_semantic_runtime_hints(
             for processor in request_processors:
                 if isinstance(processor, dict) and "agentic_query_translator" in processor:
                     has_agentic_pipeline = True
+                    # Extract agent_id and look up model_id + agent type
+                    agent_id = processor["agentic_query_translator"].get("agent_id", "")
+                    if agent_id:
+                        try:
+                            agent_resp = opensearch_client.transport.perform_request("GET", f"/_plugins/_ml/agents/{agent_id}")
+                            agentic_agent_type = agent_resp.get("type", "flow")
+                            # Flow agent: model_id is in tools[QueryPlanningTool].parameters.model_id
+                            for tool in agent_resp.get("tools", []):
+                                if tool.get("type") == "QueryPlanningTool":
+                                    agentic_model_id = tool.get("parameters", {}).get("model_id", "")
+                                    break
+                            # Conversational agent: model_id is in llm.model_id
+                            if not agentic_model_id:
+                                agentic_model_id = agent_resp.get("llm", {}).get("model_id", "")
+                        except Exception:
+                            pass
                     break
         except Exception:
             pass
@@ -4784,6 +4803,8 @@ def _resolve_semantic_runtime_hints(
         "default_pipeline": default_pipeline,
         "search_pipeline": search_pipeline,
         "has_agentic_pipeline": str(has_agentic_pipeline).lower(),
+        "agentic_model_id": agentic_model_id,
+        "agentic_agent_type": agentic_agent_type,
         "source_field": source_field,
     }
 
@@ -4928,6 +4949,7 @@ def _search_ui_search(
     debug: bool = False,
     search_intent: str = "",
     field_hint: str = "",
+    memory_id: str = "",
 ) -> dict:
     if not index_name:
         return {
@@ -4981,72 +5003,109 @@ def _search_ui_search(
         lexical_query = _build_default_lexical_query(query=query, fields=lexical_fields)
         manual_structured_clauses: list[dict[str, object]] | None = None
 
-        # Check if this is an agentic search query (multi-step question)
-        if has_agentic_pipeline and capability == "manual":
-            # Detect multi-step questions that should use agentic search
-            query_lower = query.lower()
-            agentic_indicators = [
-                " and ",
-                " or ",
-                "why",
-                "how",
-                "what are",
-                "show me",
-                "find",
-                "compare",
-                "top",
-                "best",
-                "under",
-                "over",
-                "between",
-                "?",
-            ]
-            if any(indicator in query_lower for indicator in agentic_indicators):
-                # Use agentic search with correct query format
-                executed_body = {
-                    "size": size,
-                    "query": {
-                        "agentic": {
-                            "query_text": query
-                        }
-                    }
-                }
-                query_mode = "agentic_search"
-                capability = "agentic"
-                used_semantic = True
+        # When agentic pipeline is configured, route ALL queries through it.
+        # The agentic agent handles query decomposition internally.
+        if has_agentic_pipeline:
+            agentic_query = {"query_text": query}
+            if memory_id:
+                agentic_query["memory_id"] = memory_id
+            executed_body = {
+                "size": size,
+                "query": {
+                    "agentic": agentic_query
+                },
+            }
+            query_mode = "agentic_search"
+            capability = "agentic"
+            used_semantic = True
+            
+            try:
+                response = opensearch_client.search(index=index_name, body=executed_body)
                 
-                try:
-                    response = opensearch_client.search(index=index_name, body=executed_body)
-                    
-                    # Debug: Log the raw response
-                    if debug:
-                        print(f"[DEBUG] Agentic search response: {json.dumps(response, indent=2)}")
-                    
-                    hits_out: list[dict] = []
-                    for hit in response.get("hits", {}).get("hits", []):
-                        source = hit.get("_source", {})
-                        hits_out.append(
-                            {
-                                "id": hit.get("_id"),
-                                "score": hit.get("_score"),
-                                "preview": _search_ui_preview_text(source),
-                                "source": _strip_vector_fields(source),
+                hits_out: list[dict] = []
+                for hit in response.get("hits", {}).get("hits", []):
+                    source = hit.get("_source", {})
+                    hits_out.append(
+                        {
+                            "id": hit.get("_id"),
+                            "score": hit.get("_score"),
+                            "preview": _search_ui_preview_text(source),
+                            "source": _strip_vector_fields(source),
+                        }
+                    )
+                # Extract memory_id, agent_steps_summary, dsl_query from ext field
+                ext = response.get("ext", {})
+                response_memory_id = ext.get("memory_id", "")
+                agent_steps_summary = ext.get("agent_steps_summary", "")
+                dsl_query = ext.get("dsl_query", "")
+                # Extract RAG-generated natural language answer
+                rag_answer = ""
+                rag_ext = ext.get("retrieval_augmented_generation", {})
+                if isinstance(rag_ext, dict):
+                    rag_answer = rag_ext.get("answer", "")
+                elif isinstance(ext.get("generative_qa_parameters"), dict):
+                    rag_answer = ext["generative_qa_parameters"].get("answer", "")
+                result = {
+                    "error": "",
+                    "hits": hits_out,
+                    "total": response.get("hits", {}).get("total", {}).get("value", len(hits_out)),
+                    "took_ms": response.get("took", 0),
+                    "query_mode": query_mode,
+                    "capability": capability,
+                    "used_semantic": used_semantic,
+                    "fallback_reason": fallback_reason,
+                    **({"query_body": executed_body} if debug else {}),
+                }
+                if response_memory_id:
+                    result["memory_id"] = response_memory_id
+                if agent_steps_summary:
+                    result["agent_steps_summary"] = agent_steps_summary
+                if dsl_query:
+                    result["dsl_query"] = dsl_query
+                
+                # Generate natural language summary via LLM
+                if hits_out:
+                    try:
+                        # Build context from top results
+                        context_parts = []
+                        for i, hit in enumerate(hits_out[:5]):
+                            src = hit.get("source", {})
+                            parts = [f"{i+1}."]
+                            if src.get("primaryTitle"): parts.append(src["primaryTitle"])
+                            if src.get("startYear"): parts.append(f"({src['startYear']})")
+                            if src.get("genres"): parts.append(f"- {src['genres']}")
+                            if src.get("titleType"): parts.append(f"[{src['titleType']}]")
+                            if src.get("runtimeMinutes"): parts.append(f"{src['runtimeMinutes']}min")
+                            context_parts.append(" ".join(parts))
+                        context_text = "\n".join(context_parts)
+                        total_count = result.get("total", len(hits_out))
+                        
+                        llm_prompt = f"The user asked: \"{query}\"\n\nSearch returned {total_count} results. Here are the top matches:\n{context_text}\n\nProvide a brief, conversational summary of these results. Mention specific titles and key details. Keep it under 100 words."
+                        
+                        predict_body = {
+                            "parameters": {
+                                "system_prompt": "You are a helpful movie search assistant. Summarize search results concisely.",
+                                "user_prompt": llm_prompt,
                             }
+                        }
+                        llm_response = opensearch_client.transport.perform_request(
+                            "POST",
+                            f"/_plugins/_ml/models/{runtime_hints.get('agentic_model_id', '')}/_predict",
+                            body=predict_body,
                         )
-                    return {
-                        "error": "",
-                        "hits": hits_out,
-                        "total": response.get("hits", {}).get("total", {}).get("value", len(hits_out)),
-                        "took_ms": response.get("took", 0),
-                        "query_mode": query_mode,
-                        "capability": capability,
-                        "used_semantic": used_semantic,
-                        "fallback_reason": fallback_reason,
-                        **({"query_body": executed_body} if debug else {}),
-                    }
-                except Exception as e:
-                    fallback_reason = f"agentic search failed: {e}"
-                    # Fall through to regular search logic
+                        # Extract answer from Bedrock Converse response
+                        inference = llm_response.get("inference_results", [{}])[0]
+                        output_data = inference.get("output", [{}])[0].get("dataAsMap", {})
+                        answer_text = output_data.get("output", {}).get("message", {}).get("content", [{}])[0].get("text", "")
+                        if answer_text:
+                            result["rag_answer"] = answer_text
+                    except Exception:
+                        pass  # Fall back to client-side summary
+                
+                return result
+            except Exception as e:
+                fallback_reason = f"agentic search failed: {e}"
+                # Fall through to regular search logic
 
         if capability == "manual":
             manual_structured_clauses, _ = _parse_structured_clauses(
@@ -5613,7 +5672,9 @@ def detect_index_profile(index_name: str) -> dict:
         any(hint in name.lower() for hint in _ecommerce_hints) for name in keyword_fields
     )
 
-    if has_price_field or (has_image_field and has_ecommerce_field):
+    if has_agentic:
+        template = "agent"
+    elif has_price_field or (has_image_field and has_ecommerce_field):
         template = "ecommerce"
     elif text_fields or vector_fields:
         template = "document"
@@ -5643,6 +5704,7 @@ def detect_index_profile(index_name: str) -> dict:
         "suggested_template": template,
         "has_semantic": has_semantic,
         "has_agentic": has_agentic,
+        "agentic_agent_type": runtime_hints.get("agentic_agent_type", ""),
     }
 
 
@@ -5762,6 +5824,7 @@ class _SearchUIRequestHandler(BaseHTTPRequestHandler):
             query_text = params.get("q", [""])[0]
             search_intent = params.get("intent", [""])[0]
             field_hint = params.get("field", [""])[0]
+            memory_id_param = params.get("memory_id", [""])[0]
             debug_param = params.get("debug", ["0"])[0].strip().lower()
             debug_mode = debug_param in {"1", "true", "yes", "on"}
             try:
@@ -5778,6 +5841,7 @@ class _SearchUIRequestHandler(BaseHTTPRequestHandler):
                     debug=debug_mode,
                     search_intent=search_intent,
                     field_hint=field_hint,
+                    memory_id=memory_id_param,
                 )
                 self._write_json(result)
             except Exception as e:

--- a/opensearch_orchestrator/ui/search_builder/app.jsx
+++ b/opensearch_orchestrator/ui/search_builder/app.jsx
@@ -3,6 +3,7 @@ const { useEffect, useState, useRef, useCallback } = React;
 const TEMPLATES = [
   { id: "document", label: "Document" },
   { id: "ecommerce", label: "E-Commerce" },
+  { id: "agent", label: "Agent" },
 ];
 
 function TemplateIcon({ id }) {
@@ -18,6 +19,13 @@ function TemplateIcon({ id }) {
     return (
       <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
         <circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/>
+      </svg>
+    );
+  }
+  if (id === "agent") {
+    return (
+      <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
       </svg>
     );
   }
@@ -259,9 +267,9 @@ function AgenticChat({ messages, loading }) {
             </svg>
           </div>
           <div className="chat-empty-title">Conversational Search</div>
-          <div className="chat-empty-desc">Ask questions in natural language. I'll search the index and summarize what I find.</div>
+          <div className="chat-empty-desc">Have a conversation with the AI agent about your data. Ask follow-up questions and the agent will remember the context of your conversation.</div>
           <div className="chat-empty-examples">
-            Try: "Show me sci-fi movies rated above 8" or "What are the best films by Christopher Nolan?"
+            Try: "Show me sci-fi movies from the 1990s" then follow up with "Which of those are also comedies?"
           </div>
         </div>
       )}
@@ -273,6 +281,17 @@ function AgenticChat({ messages, loading }) {
             <div className="chat-assistant">
               {msg.results && msg.results.length > 0 ? (
                 <>
+                  {msg.agent_steps_summary && (
+                    <details className="chat-agent-reasoning" open>
+                      <summary>Agent reasoning</summary>
+                      <div className="chat-reasoning-content">
+                        <div className="chat-reasoning-section">
+                          <div className="chat-reasoning-label">Steps</div>
+                          <pre className="chat-reasoning-pre">{msg.agent_steps_summary}</pre>
+                        </div>
+                      </div>
+                    </details>
+                  )}
                   <div className="chat-summary">
                     {renderChatText(msg.summary || generateChatSummary(msg.query, msg.results, msg.total))}
                   </div>
@@ -294,6 +313,16 @@ function AgenticChat({ messages, loading }) {
                       ))}
                     </div>
                   </details>
+                  {msg.dsl_query && (
+                    <details className="chat-agent-reasoning">
+                      <summary>Generated DSL</summary>
+                      <div className="chat-reasoning-content">
+                        <div className="chat-reasoning-section">
+                          <pre className="chat-reasoning-pre">{(() => { try { return JSON.stringify(JSON.parse(msg.dsl_query), null, 2); } catch(e) { return msg.dsl_query; } })()}</pre>
+                        </div>
+                      </div>
+                    </details>
+                  )}
                 </>
               ) : msg.error ? (
                 <div className="chat-error">{msg.error}</div>
@@ -609,6 +638,16 @@ function App() {
   const [showSettings, setShowSettings] = useState(false);
   const [darkMode, setDarkMode] = useState(false);
 
+  // Chat / agent state
+  const [chatMessages, setChatMessages] = useState([]);
+  const [memoryId, setMemoryId] = useState(null);
+  const [prevComparisonEnabled, setPrevComparisonEnabled] = useState(false);
+  const [ragAnswer, setRagAnswer] = useState("");
+  const [agentStepsSummary, setAgentStepsSummary] = useState("");
+  const [dslQuery, setDslQuery] = useState("");
+  // "search" = google-like (flow agent), "chat" = chatbox (conversational agent)
+  const [agenticMode, setAgenticMode] = useState("search");
+
   useEffect(() => {
     document.documentElement.classList.toggle("dark", darkMode);
   }, [darkMode]);
@@ -653,6 +692,17 @@ function App() {
     manual: "Manual",
   };
 
+  // ---- Template change with comparison mode management ----
+  const handleTemplateChange = (newTemplate) => {
+    if (newTemplate === "agent" && activeTemplate !== "agent") {
+      setPrevComparisonEnabled(comparisonEnabled);
+      setComparisonEnabled(false);
+    } else if (newTemplate !== "agent" && activeTemplate === "agent") {
+      setComparisonEnabled(prevComparisonEnabled);
+    }
+    setActiveTemplate(newTemplate);
+  };
+
   // ---- Schema fetch ----
   const fetchSchema = useCallback(async (index) => {
     if (!index) return;
@@ -661,10 +711,14 @@ function App() {
       const data = await res.json();
       if (!data.error) {
         setSchema(data);
-        setActiveTemplate(data.suggested_template || "document");
+        handleTemplateChange(data.suggested_template || "document");
+        // Set agentic mode based on agent type — only on initial load
+        if (data.agentic_agent_type && !schema) {
+          setAgenticMode(data.agentic_agent_type === "conversational" ? "chat" : "search");
+        }
       }
     } catch (_) {}
-  }, []);
+  }, [handleTemplateChange]);
 
   // ---- Suggestions ----
   const loadSuggestions = async (index) => {
@@ -795,8 +849,61 @@ function App() {
     };
   }, [indexName, query, capability, queryMode, autocompleteField, comparisonEnabled, compareIndex2]);
 
+  // ---- Agent Search ----
+  const runAgentSearch = async (overrideQuery = null) => {
+    const effectiveQuery = (overrideQuery !== null ? overrideQuery : query).trim();
+    const effectiveIndex = indexName.trim();
+    if (!effectiveIndex || !effectiveQuery) return;
+
+    setChatMessages(prev => [...prev, { role: "user", text: effectiveQuery }]);
+    setLoading(true);
+    setError("");
+
+    try {
+      const qs = new URLSearchParams();
+      qs.set("index", effectiveIndex);
+      qs.set("q", effectiveQuery);
+      qs.set("size", String(parseInt(searchSize, 10) || 20));
+      qs.set("debug", "1");
+      if (memoryId) qs.set("memory_id", memoryId);
+
+      const res = await fetch(`/api/search?${qs.toString()}`);
+      const data = await res.json();
+
+      if (data.error) {
+        const friendlyError = data.error.includes("expired") 
+          ? "AI agent credentials have expired. Please refresh and try again."
+          : data.error.includes("timeout") 
+          ? "The AI agent took too long to respond. Please try a simpler question."
+          : "I had trouble processing your question. Please try rephrasing it.";
+        setChatMessages(prev => [...prev, { role: "assistant", error: friendlyError }]);
+      } else {
+        const hits = Array.isArray(data.hits) ? data.hits : [];
+        const summary = generateChatSummary(effectiveQuery, hits, data.total ?? 0);
+        setChatMessages(prev => [...prev, {
+          role: "assistant",
+          query: effectiveQuery,
+          results: hits,
+          total: data.total ?? 0,
+          took_ms: data.took_ms ?? 0,
+          capability: data.capability || "",
+          summary: data.rag_answer || summary,
+          agent_steps_summary: data.agent_steps_summary || "",
+          dsl_query: data.dsl_query || "",
+        }]);
+        if (data.memory_id) setMemoryId(data.memory_id);
+      }
+    } catch (err) {
+      setChatMessages(prev => [...prev, { role: "assistant", error: "Something went wrong. Please try again." }]);
+    } finally {
+      setLoading(false);
+      setQuery("");
+    }
+  };
+
   // ---- Search ----
   const runSearch = async (overrideQuery = null, options = {}) => {
+    if (activeTemplate === "agent" && agenticMode === "chat") { runAgentSearch(overrideQuery); return; }
     // In comparison mode, ComparisonView handles search via its own useEffect on query
     if (comparisonEnabled) return;
     const effectiveQuery = (overrideQuery !== null ? overrideQuery : query).trim();
@@ -831,6 +938,9 @@ function App() {
         setCapability(String(data.capability || ""));
         setFallbackReason(String(data.fallback_reason || ""));
         setUsedSemantic(Boolean(data.used_semantic));
+        setRagAnswer(String(data.rag_answer || ""));
+        setAgentStepsSummary(String(data.agent_steps_summary || ""));
+        setDslQuery(String(data.dsl_query || ""));
         await loadSuggestions(effectiveIndex);
       }
     } catch (err) {
@@ -934,6 +1044,8 @@ function App() {
                       setIndexName(v);
                       loadSuggestions(v);
                       fetchSchema(v);
+                      setChatMessages([]);
+                      setMemoryId(null);
                     }
                   }}
                   placeholder="Select index..."
@@ -999,7 +1111,7 @@ function App() {
                   title=""
                   onClick={() => {
                     if (disabled) return;
-                    setActiveTemplate(t.id);
+                    handleTemplateChange(t.id);
                   }}
                 >
                   <div className="tpl-card-icon"><TemplateIcon id={t.id} /></div>
@@ -1058,8 +1170,28 @@ function App() {
       )}
 
       <section className="search-panel">
-            {/* Standard search bar */}
+            {/* Search bar — always visible. In agent mode, toggle is inline */}
             <div className="search-row">
+              {activeTemplate === "agent" && (
+                <div className="agentic-mode-toggle" role="radiogroup" aria-label="Agentic mode">
+                  <button
+                    className={`agentic-mode-btn ${agenticMode === "search" ? "active" : ""}`}
+                    onClick={() => setAgenticMode("search")}
+                    role="radio" aria-checked={agenticMode === "search"}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+                    Search
+                  </button>
+                  <button
+                    className={`agentic-mode-btn ${agenticMode === "chat" ? "active" : ""}`}
+                    onClick={() => setAgenticMode("chat")}
+                    role="radio" aria-checked={agenticMode === "chat"}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+                    Chat
+                  </button>
+                </div>
+              )}
               <div className="query-wrap">
                 <span className="query-icon">
                   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -1069,8 +1201,8 @@ function App() {
                 <input
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") { setAutocompleteOptions([]); runSearch(); } }}
-                  placeholder="Search..."
+                  onKeyDown={(e) => { if (e.key === "Enter") { setAutocompleteOptions([]); runSearch(query); } }}
+                  placeholder={activeTemplate === "agent" ? "Ask a question..." : "Search..."}
                 />
                 {autocompleteOptions.length > 0 && (
                   <div className="autocomplete-menu">
@@ -1083,12 +1215,18 @@ function App() {
                   </div>
                 )}
               </div>
-              <button className="search-btn" onClick={() => runSearch()} disabled={loading}>
-                {loading ? "..." : "Search"}
+              <button className="search-btn" onClick={() => runSearch(query)} disabled={loading}>
+                {loading ? "..." : (activeTemplate === "agent" && agenticMode === "chat" ? "Send" : "Search")}
               </button>
+              {activeTemplate === "agent" && agenticMode === "chat" && chatMessages.length > 0 && (
+                <button className="clear-chat-btn" onClick={() => { setChatMessages([]); setMemoryId(null); }}>
+                  Clear
+                </button>
+              )}
             </div>
 
-            {/* Suggestions */}
+            {/* Suggestions - hidden in agent mode */}
+            {activeTemplate !== "agent" && (
             <div className="suggestions">
               <div className="chips">
                 {suggestions.slice(0, 5).map((item) => (
@@ -1103,6 +1241,7 @@ function App() {
                   ))}
                 </div>
             </div>
+            )}
 
             {/* Results area: comparison view or standard single-index results */}
             {comparisonEnabled ? (
@@ -1118,18 +1257,30 @@ function App() {
               />
             ) : (
               <>
-                {/* Status row */}
+                {/* Status row — only shown after a search has been performed */}
+                {(activeTemplate !== "agent" || agenticMode === "search") && results.length > 0 && (
                 <div className="status-row">
                   <span>{stats}</span>
                   {queryMode && <span>mode: {queryMode}</span>}
                   {capability && <span>capability: {capability}</span>}
-                  {!error && <span>semantic: {usedSemantic ? "on" : "off"}</span>}
-                  {fallbackReason && <span>fallback: {fallbackReason}</span>}
+                  {activeTemplate !== "agent" && !error && <span>semantic: {usedSemantic ? "on" : "off"}</span>}
                   {error && <span className="error">{error}</span>}
                 </div>
+                )}
 
-                {/* Loading bar */}
-                {loading && (
+                {/* Agentic fallback warning — shown when agentic search failed and fell back to BM25 */}
+                {activeTemplate === "agent" && fallbackReason && fallbackReason.includes("agentic search failed") && (
+                  <div className="agentic-fallback-warning">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+                    <span>AI agent unavailable — showing standard search results.
+                      {fallbackReason.includes("expired") && " AWS credentials may have expired."}
+                      {fallbackReason.includes("timeout") && " The request timed out."}
+                    </span>
+                  </div>
+                )}
+
+                {/* Loading bar - hidden in agent chat mode (has typing indicator) */}
+                {loading && (activeTemplate !== "agent" || agenticMode === "search") && (
                   <div className="loading-container">
                     <div className="loading-bar"><div className="loading-bar-progress"></div></div>
                     <div className="loading-text">Searching...</div>
@@ -1137,6 +1288,67 @@ function App() {
                 )}
 
                 {/* Template-specific results */}
+                {activeTemplate === "agent" && agenticMode === "chat" && (
+                  <AgenticChat messages={chatMessages} loading={loading} />
+                )}
+                {activeTemplate === "agent" && agenticMode === "search" && (
+                  <>
+                    {!loading && results.length === 0 && !ragAnswer && !error && (
+                      <div className="chat-empty">
+                        <div className="chat-empty-icon">
+                          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round" style={{opacity: 0.3}}>
+                            <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                          </svg>
+                        </div>
+                        <div className="chat-empty-title">Agentic Search</div>
+                        <div className="chat-empty-desc">Ask questions in natural language. The AI agent will decompose your query and find relevant results.</div>
+                        <div className="chat-empty-examples">
+                          Try: "Show me sci-fi movies from the 1990s" or "Find horror movies longer than 2 hours"
+                        </div>
+                      </div>
+                    )}
+                    {ragAnswer && (
+                      <div className="rag-answer-card">
+                        <div className="rag-answer-text">{renderChatText(ragAnswer)}</div>
+                      </div>
+                    )}
+                    {(agentStepsSummary || dslQuery) && results.length > 0 && (
+                      <div className="search-reasoning-bar">
+                        {agentStepsSummary && (
+                          <details className="chat-agent-reasoning">
+                            <summary>Agent reasoning</summary>
+                            <div className="chat-reasoning-content">
+                              <div className="chat-reasoning-section">
+                                <pre className="chat-reasoning-pre">{agentStepsSummary}</pre>
+                              </div>
+                            </div>
+                          </details>
+                        )}
+                        {dslQuery && (
+                          <details className="chat-agent-reasoning">
+                            <summary>Generated DSL</summary>
+                            <div className="chat-reasoning-content">
+                              <div className="chat-reasoning-section">
+                                <pre className="chat-reasoning-pre">{(() => { try { return JSON.stringify(JSON.parse(dslQuery), null, 2); } catch(e) { return dslQuery; } })()}</pre>
+                              </div>
+                            </div>
+                          </details>
+                        )}
+                      </div>
+                    )}
+                    {results.length > 0 && <DocumentResults results={results} loading={loading} filterSource={filterSource} />}
+                  </>
+                )}
+                {activeTemplate === "document" && (
+                  <>
+                    {ragAnswer && (
+                      <div className="rag-answer-card">
+                        <div className="rag-answer-text">{renderChatText(ragAnswer)}</div>
+                      </div>
+                    )}
+                    <DocumentResults results={results} loading={loading} filterSource={filterSource} />
+                  </>
+                )}
                 {(activeTemplate === "ecommerce" || activeTemplate === "media") && (
                   <EcommerceResults results={results} loading={loading} schema={schema} fieldOverrides={fieldOverrides} filterSource={filterSource} />
                 )}

--- a/opensearch_orchestrator/ui/search_builder/app.jsx
+++ b/opensearch_orchestrator/ui/search_builder/app.jsx
@@ -6,6 +6,21 @@ const TEMPLATES = [
   { id: "agent", label: "Agent" },
 ];
 
+const AGENT_PROMPTS = {
+  search: [
+    "Show me sci-fi movies from the 1990s",
+    "Top rated crime films",
+    "Movies directed by Christopher Nolan",
+    "Find animated films with high ratings",
+  ],
+  chat: [
+    "What are the highest rated movies?",
+    "Tell me about sci-fi films in the collection",
+    "Which directors have multiple movies?",
+    "Recommend a good thriller",
+  ],
+};
+
 function TemplateIcon({ id }) {
   const size = 20;
   if (id === "document") {
@@ -251,7 +266,7 @@ function renderChatText(text) {
   });
 }
 
-function AgenticChat({ messages, loading }) {
+function AgenticChat({ messages, loading, onPromptClick }) {
   const endRef = useRef(null);
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -267,9 +282,11 @@ function AgenticChat({ messages, loading }) {
             </svg>
           </div>
           <div className="chat-empty-title">Conversational Search</div>
-          <div className="chat-empty-desc">Have a conversation with the AI agent about your data. Ask follow-up questions and the agent will remember the context of your conversation.</div>
-          <div className="chat-empty-examples">
-            Try: "Show me sci-fi movies from the 1990s" then follow up with "Which of those are also comedies?"
+          <div className="chat-empty-desc">Ask follow-up questions and the agent will remember the context of your conversation.</div>
+          <div className="suggested-prompts">
+            {AGENT_PROMPTS.chat.map((p) => (
+              <button key={p} className="suggested-prompt" onClick={() => onPromptClick && onPromptClick(p)}>{p}</button>
+            ))}
           </div>
         </div>
       )}
@@ -296,7 +313,7 @@ function AgenticChat({ messages, loading }) {
                     {renderChatText(msg.summary || generateChatSummary(msg.query, msg.results, msg.total))}
                   </div>
                   <div className="chat-meta-bar">
-                    <span>{msg.total ?? msg.results.length} result(s) \u2022 {msg.took_ms ?? 0}ms</span>
+                    <span>{msg.total ?? msg.results.length} result(s) {"\u2022"} {msg.took_ms ?? 0}ms</span>
                     {msg.capability && <span className="chat-cap-badge">{msg.capability}</span>}
                   </div>
                   <details className="chat-sources">
@@ -704,6 +721,7 @@ function App() {
   };
 
   // ---- Schema fetch ----
+  const schemaLoadedRef = useRef(false);
   const fetchSchema = useCallback(async (index) => {
     if (!index) return;
     try {
@@ -711,14 +729,21 @@ function App() {
       const data = await res.json();
       if (!data.error) {
         setSchema(data);
-        handleTemplateChange(data.suggested_template || "document");
-        // Set agentic mode based on agent type — only on initial load
-        if (data.agentic_agent_type && !schema) {
-          setAgenticMode(data.agentic_agent_type === "conversational" ? "chat" : "search");
+        // Only apply suggested_template on the first load, not on every refetch
+        if (!schemaLoadedRef.current) {
+          schemaLoadedRef.current = true;
+          const suggested = data.suggested_template || "document";
+          setActiveTemplate(suggested);
+          if (suggested === "agent") {
+            setComparisonEnabled(false);
+          }
+          if (data.agentic_agent_type) {
+            setAgenticMode(data.agentic_agent_type === "conversational" ? "chat" : "search");
+          }
         }
       }
     } catch (_) {}
-  }, [handleTemplateChange]);
+  }, []);
 
   // ---- Suggestions ----
   const loadSuggestions = async (index) => {
@@ -1103,21 +1128,44 @@ function App() {
           <div className="tpl-grid">
             {TEMPLATES.map((t) => {
               const disabled = !!t.disabled;
+              const isAgent = t.id === "agent";
+              const isActive = activeTemplate === t.id;
               return (
-                <button
-                  key={t.id}
-                  className={`tpl-card ${activeTemplate === t.id ? "on" : ""} ${disabled ? "disabled" : ""}`}
-                  disabled={disabled}
-                  title=""
-                  onClick={() => {
-                    if (disabled) return;
-                    handleTemplateChange(t.id);
-                  }}
-                >
-                  <div className="tpl-card-icon"><TemplateIcon id={t.id} /></div>
-                  <div className="tpl-card-label">{t.label}</div>
-                  {schema?.suggested_template === t.id && <span className="template-auto">auto</span>}
-                </button>
+                <div key={t.id} className={`tpl-card-wrap ${isAgent && isActive ? "expanded" : ""}`}>
+                  <button
+                    className={`tpl-card ${isActive ? "on" : ""} ${disabled ? "disabled" : ""}`}
+                    disabled={disabled}
+                    title=""
+                    onClick={() => {
+                      if (disabled) return;
+                      handleTemplateChange(t.id);
+                    }}
+                  >
+                    <div className="tpl-card-icon"><TemplateIcon id={t.id} /></div>
+                    <div className="tpl-card-label">{t.label}</div>
+                    {schema?.suggested_template === t.id && <span className="template-auto">auto</span>}
+                  </button>
+                  {isAgent && isActive && (
+                    <div className="agent-mode-sub">
+                      <button
+                        className={`agent-mode-opt ${agenticMode === "search" ? "active" : ""}`}
+                        onClick={(e) => { e.stopPropagation(); setAgenticMode("search"); }}
+                      >
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+                        Search
+                        <span className="agent-mode-opt-desc">Answer + results</span>
+                      </button>
+                      <button
+                        className={`agent-mode-opt ${agenticMode === "chat" ? "active" : ""}`}
+                        onClick={(e) => { e.stopPropagation(); setAgenticMode("chat"); }}
+                      >
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+                        Chat
+                        <span className="agent-mode-opt-desc">Conversational</span>
+                      </button>
+                    </div>
+                  )}
+                </div>
               );
             })}
           </div>
@@ -1169,29 +1217,10 @@ function App() {
         </div>
       )}
 
-      <section className="search-panel">
-            {/* Search bar — always visible. In agent mode, toggle is inline */}
+      <section className={`search-panel ${activeTemplate === "agent" && agenticMode === "chat" ? "chat-layout" : ""}`}>
+            {/* Search input bar — hidden for chat mode (lives at bottom) */}
+            {!(activeTemplate === "agent" && agenticMode === "chat") && (
             <div className="search-row">
-              {activeTemplate === "agent" && (
-                <div className="agentic-mode-toggle" role="radiogroup" aria-label="Agentic mode">
-                  <button
-                    className={`agentic-mode-btn ${agenticMode === "search" ? "active" : ""}`}
-                    onClick={() => setAgenticMode("search")}
-                    role="radio" aria-checked={agenticMode === "search"}
-                  >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-                    Search
-                  </button>
-                  <button
-                    className={`agentic-mode-btn ${agenticMode === "chat" ? "active" : ""}`}
-                    onClick={() => setAgenticMode("chat")}
-                    role="radio" aria-checked={agenticMode === "chat"}
-                  >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-                    Chat
-                  </button>
-                </div>
-              )}
               <div className="query-wrap">
                 <span className="query-icon">
                   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -1216,21 +1245,23 @@ function App() {
                 )}
               </div>
               <button className="search-btn" onClick={() => runSearch(query)} disabled={loading}>
-                {loading ? "..." : (activeTemplate === "agent" && agenticMode === "chat" ? "Send" : "Search")}
+                {loading ? "..." : "Search"}
               </button>
-              {activeTemplate === "agent" && agenticMode === "chat" && chatMessages.length > 0 && (
-                <button className="clear-chat-btn" onClick={() => { setChatMessages([]); setMemoryId(null); }}>
-                  Clear
-                </button>
-              )}
             </div>
+            )}
 
-            {/* Suggestions - hidden in agent mode */}
-            {activeTemplate !== "agent" && (
+            {/* Suggestions - shown under search bar for all modes except chat */}
+            {!(activeTemplate === "agent" && agenticMode === "chat") && (
             <div className="suggestions">
               <div className="chips">
-                {suggestions.slice(0, 5).map((item) => (
-                    <button key={`${item.text}-${item.capability || "none"}`} className="chip" onClick={() => onSuggestionClick(item)}>
+                {(activeTemplate === "agent"
+                  ? AGENT_PROMPTS.search.map((text) => ({ text, capability: "" }))
+                  : suggestions.slice(0, 5)
+                ).map((item) => (
+                    <button key={`${item.text}-${item.capability || "none"}`} className="chip" onClick={() => {
+                      if (activeTemplate === "agent") { setQuery(item.text); runSearch(item.text); }
+                      else onSuggestionClick(item);
+                    }}>
                       <span>{item.text}</span>
                       {item.capability && (
                         <span className={`cap-badge cap-${item.capability}`}>
@@ -1289,7 +1320,35 @@ function App() {
 
                 {/* Template-specific results */}
                 {activeTemplate === "agent" && agenticMode === "chat" && (
-                  <AgenticChat messages={chatMessages} loading={loading} />
+                  <div className="chat-messages-area">
+                    {chatMessages.length > 0 && (
+                      <div className="chat-toolbar">
+                        <button className="new-chat-btn" onClick={() => { setChatMessages([]); setMemoryId(null); }}>
+                          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                          New conversation
+                        </button>
+                      </div>
+                    )}
+                    <AgenticChat messages={chatMessages} loading={loading} onPromptClick={(text) => { setQuery(text); runSearch(text); }} />
+                    <div className="chat-input-bar">
+                      <div className="query-wrap">
+                        <span className="query-icon">
+                          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                            <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                          </svg>
+                        </span>
+                        <input
+                          value={query}
+                          onChange={(e) => setQuery(e.target.value)}
+                          onKeyDown={(e) => { if (e.key === "Enter") { setAutocompleteOptions([]); runSearch(query); } }}
+                          placeholder="Ask a question..."
+                        />
+                      </div>
+                      <button className="search-btn" onClick={() => runSearch(query)} disabled={loading}>
+                        {loading ? "..." : "Send"}
+                      </button>
+                    </div>
+                  </div>
                 )}
                 {activeTemplate === "agent" && agenticMode === "search" && (
                   <>
@@ -1302,9 +1361,6 @@ function App() {
                         </div>
                         <div className="chat-empty-title">Agentic Search</div>
                         <div className="chat-empty-desc">Ask questions in natural language. The AI agent will decompose your query and find relevant results.</div>
-                        <div className="chat-empty-examples">
-                          Try: "Show me sci-fi movies from the 1990s" or "Find horror movies longer than 2 hours"
-                        </div>
                       </div>
                     )}
                     {ragAnswer && (
@@ -1352,7 +1408,6 @@ function App() {
                 {(activeTemplate === "ecommerce" || activeTemplate === "media") && (
                   <EcommerceResults results={results} loading={loading} schema={schema} fieldOverrides={fieldOverrides} filterSource={filterSource} />
                 )}
-                {activeTemplate === "document" && <DocumentResults results={results} loading={loading} filterSource={filterSource} />}
               </>
             )}
       </section>

--- a/opensearch_orchestrator/ui/search_builder/styles.css
+++ b/opensearch_orchestrator/ui/search_builder/styles.css
@@ -417,7 +417,7 @@ body {
 }
 
 /* Template cards */
-.tpl-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
+.tpl-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
 
 .tpl-card {
   border: 1px solid var(--border);
@@ -1015,7 +1015,7 @@ pre {
 .ecommerce-metric strong { color: var(--foreground); }
 
 /* Agentic Chat */
-.chat-container { display: flex; flex-direction: column; height: 520px; }
+.chat-container { display: flex; flex-direction: column; min-height: 200px; }
 
 .chat-messages {
   flex: 1;
@@ -1088,6 +1088,101 @@ pre {
 .chat-sources summary { cursor: pointer; font-weight: 500; padding: 4px 0; }
 .chat-sources summary:hover { color: var(--primary); }
 
+.chat-agent-reasoning { font-size: 13px; color: var(--muted-foreground); margin-top: 6px; }
+.chat-agent-reasoning summary { cursor: pointer; font-weight: 500; padding: 4px 0; }
+.chat-agent-reasoning summary:hover { color: var(--primary); }
+.chat-reasoning-content { margin-top: 8px; display: flex; flex-direction: column; gap: 10px; }
+.chat-reasoning-section { }
+.chat-reasoning-label { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--primary); margin-bottom: 4px; }
+.chat-reasoning-pre { font-size: 12px; line-height: 1.5; background: var(--accent); padding: 8px 12px; border-radius: var(--radius-md); overflow-x: auto; white-space: pre-wrap; word-break: break-word; }
+
+/* RAG Answer Card (flow agent, document template) */
+.rag-answer-card {
+  background: var(--secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 12px 16px;
+  margin-bottom: 12px;
+  line-height: 1.6;
+}
+.rag-answer-text { font-size: 14px; color: var(--foreground); white-space: pre-line; line-height: 1.6; }
+.rag-answer-text strong { font-weight: 600; color: var(--primary); }
+
+.search-reasoning-bar {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+.search-reasoning-bar .chat-agent-reasoning {
+  flex: 1;
+}
+
+/* Agentic Fallback Warning */
+.agentic-fallback-warning {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  background: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: var(--radius-lg);
+  font-size: 13px;
+  color: #92400e;
+}
+.dark .agentic-fallback-warning {
+  background: rgba(245, 158, 11, 0.15);
+  border-color: rgba(245, 158, 11, 0.4);
+  color: #fbbf24;
+}
+
+/* Agentic Mode Toggle — inline in search row */
+.clear-chat-btn {
+  border: 1px solid var(--border);
+  background: var(--background);
+  color: var(--muted-foreground);
+  padding: 4px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 150ms ease, color 150ms ease;
+}
+.clear-chat-btn:hover {
+  background: var(--accent);
+  color: var(--foreground);
+}
+
+.agentic-mode-toggle {
+  display: flex;
+  border-radius: var(--radius-full);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.agentic-mode-btn {
+  border: none;
+  background: var(--background);
+  color: var(--muted-foreground);
+  padding: 4px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  transition: background 150ms ease, color 150ms ease;
+}
+.agentic-mode-btn.active {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+.agentic-mode-btn:not(.active):hover {
+  background: var(--accent);
+}
+
 .chat-source-list { margin-top: 8px; display: flex; flex-direction: column; gap: 6px; }
 
 .chat-source-item { display: flex; gap: 8px; padding: 6px 0; border-top: 1px solid rgba(0,0,0,0.06); }
@@ -1149,6 +1244,38 @@ pre {
 .chat-input:focus {
   border-color: var(--primary);
   box-shadow: 0 0 0 3px rgba(2,132,199,0.15);
+}
+
+.chat-input-bar {
+  display: flex;
+  gap: 8px;
+  padding: 12px 0 0;
+  border-top: 1px solid var(--border);
+  align-items: center;
+}
+
+.chat-send-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: var(--primary);
+  color: white;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: opacity 150ms ease;
+}
+
+.chat-send-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chat-send-btn:not(:disabled):hover {
+  opacity: 0.85;
 }
 
 /* ---------------------------------------------------------------------------

--- a/opensearch_orchestrator/ui/search_builder/styles.css
+++ b/opensearch_orchestrator/ui/search_builder/styles.css
@@ -1015,6 +1015,35 @@ pre {
 .ecommerce-metric strong { color: var(--foreground); }
 
 /* Agentic Chat */
+.chat-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 500px;
+}
+
+.chat-messages-area {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.chat-messages-area .chat-messages {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.chat-input-bar {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+  padding-top: 12px;
+  margin-top: auto;
+  border-top: 1px solid var(--border);
+}
+
+.chat-input-bar .query-wrap { flex: 1; }
+
 .chat-container { display: flex; flex-direction: column; min-height: 200px; }
 
 .chat-messages {
@@ -1040,6 +1069,34 @@ pre {
 .chat-empty-title { font-size: 18px; font-weight: 600; color: var(--foreground); }
 .chat-empty-desc { font-size: 14px; max-width: 400px; line-height: 1.5; }
 .chat-empty-examples { font-size: 13px; color: var(--primary); font-style: italic; max-width: 420px; }
+
+.suggested-prompts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 8px;
+  max-width: 520px;
+}
+
+.suggested-prompt {
+  background: var(--accent);
+  color: var(--primary);
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  padding: 8px 16px;
+  font-size: 13px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: all 150ms ease;
+  line-height: 1.3;
+}
+
+.suggested-prompt:hover {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+}
 
 .chat-bubble { max-width: 85%; animation: slide-up 200ms ease-out both; }
 .chat-bubble.chat-user { align-self: flex-end; }
@@ -1137,50 +1194,99 @@ pre {
 }
 
 /* Agentic Mode Toggle — inline in search row */
-.clear-chat-btn {
-  border: 1px solid var(--border);
-  background: var(--background);
-  color: var(--muted-foreground);
-  padding: 4px 12px;
-  font-size: 13px;
-  font-weight: 500;
-  font-family: var(--font-sans);
-  border-radius: var(--radius-lg);
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: background 150ms ease, color 150ms ease;
-}
-.clear-chat-btn:hover {
-  background: var(--accent);
-  color: var(--foreground);
+/* New conversation button */
+.chat-input-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 6px;
+  padding-bottom: 2px;
 }
 
-.agentic-mode-toggle {
+.chat-toolbar {
   display: flex;
-  border-radius: var(--radius-full);
-  overflow: hidden;
-  border: 1px solid var(--border);
-  flex-shrink: 0;
+  justify-content: flex-end;
+  padding-bottom: 4px;
 }
-.agentic-mode-btn {
-  border: none;
-  background: var(--background);
-  color: var(--muted-foreground);
-  padding: 4px 12px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
+
+.new-chat-btn {
   display: flex;
   align-items: center;
   gap: 4px;
-  transition: background 150ms ease, color 150ms ease;
+  border: none;
+  background: none;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-md);
+  transition: color 150ms ease, background 150ms ease;
 }
-.agentic-mode-btn.active {
+
+.new-chat-btn:hover {
+  color: var(--primary);
+  background: var(--accent);
+}
+
+/* Agent mode sub-selector inside card */
+.tpl-card-wrap {
+  display: flex;
+  flex-direction: column;
+}
+
+.tpl-card-wrap .tpl-card {
+  flex: 1;
+}
+
+.tpl-card-wrap.expanded .tpl-card {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom: none;
+  margin-bottom: 0;
+}
+
+.agent-mode-sub {
+  display: flex;
+  background: var(--oui-lightest-shade);
+  border: 1px solid var(--primary);
+  border-top: 1px solid var(--border);
+  border-bottom-left-radius: var(--radius-xl);
+  border-bottom-right-radius: var(--radius-xl);
+  overflow: hidden;
+}
+
+.agent-mode-opt {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 7px 8px;
+  border: none;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.agent-mode-opt-desc {
+  font-weight: 400;
+  opacity: 0.65;
+}
+
+.agent-mode-opt.active {
   background: var(--primary);
   color: var(--primary-foreground);
+  font-weight: 600;
 }
-.agentic-mode-btn:not(.active):hover {
-  background: var(--accent);
+
+.agent-mode-opt:not(.active):hover {
+  background: var(--background);
+  color: var(--foreground);
 }
 
 .chat-source-list { margin-top: 8px; display: flex; flex-direction: column; gap: 6px; }


### PR DESCRIPTION
### Description
UI improvements to the agent template's Search/Chat mode selector and chat layout, building on [#83](https://github.com/opensearch-project/opensearch-launchpad/pull/83).

- Embedded the Search/Chat mode toggle directly into the Agent template card as an expandable sub-selector, keeping it visually consistent with the existing template card pattern
- Moved the chat input bar to the bottom of the chat area for a more natural conversational UX
- Added suggested prompt pills under the search bar for all templates (document, ecommerce, agent search)
- Changed "Clear" action to a "New conversation" action in the chat messages area

Kiro suggested fixes but not sure if related to the work I did:
- Fixed an infinite schema fetch loop caused by a `useCallback` dependency cycle in `fetchSchema`
- Fixed duplicate `DocumentResults` render for the document template
- Fixed unicode bullet character rendering in chat meta bar
- Cleaned up unused CSS from previous toggle iterations

### Issues Resolved
Builds on #83 — improves the agent mode UX based on design feedback.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here]
(https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
