### PR TITLE
add auto-sync CI workflow to agent-skills

### DIFF
--- a/.github/scripts/sync_to_agent_skills.py
+++ b/.github/scripts/sync_to_agent_skills.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Sync opensearch-launchpad skills to opensearch-agent-skills.
+
+Usage: python3 sync_to_agent_skills.py <source_root> <target_root>
+
+All content is identical between repos. The only transformations are:
+  - Path references: references/knowledge/ → launchpad/, references/aws-* → aws/*, etc.
+  - ui.py: SEARCH_UI_STATIC_DIR points to scripts/ui/ instead of shared/ui/
+  - UI assets live at scripts/ui/ instead of shared/ui/
+  - Test imports use "opensearch-skills" instead of "opensearch-launchpad"
+  - test_agent_skills_standalone_assets.py is maintained separately (not synced)
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+
+# Path replacement map for SKILL.md
+SKILL_MD_REPLACEMENTS = [
+    ("name: opensearch-launchpad", "name: opensearch-skills"),
+    (
+        "The `opensearch-launchpad` repository cloned locally",
+        "The `opensearch-skills` skill directory available locally",
+    ),
+    ("references/knowledge/", "launchpad/"),
+    ("references/observability/", "observability/"),
+    ("references/cli-reference.md", "cli-reference.md"),
+    ("references/aws-reference.md", "aws/reference.md"),
+    ("references/aws-domain-", "aws/domain-"),
+    ("references/aws-serverless-", "aws/serverless-"),
+]
+
+# Path replacement map for aws md internal links
+AWS_MD_REPLACEMENTS = [
+    ("(aws-domain-", "(domain-"),
+    ("(aws-serverless-", "(serverless-"),
+]
+
+# ui.py replacements
+UI_PY_REPLACEMENTS = [
+    (
+        'SEARCH_UI_STATIC_DIR = Path(__file__).resolve().parents[4] / "shared" / "ui"',
+        'SEARCH_UI_STATIC_DIR = _SCRIPT_DIR / "ui"',
+    ),
+    (
+        "Make sure you cloned the full opensearch-launchpad repository.",
+        "Make sure you have the full opensearch-skills skill directory.",
+    ),
+]
+
+# Test file replacements
+TEST_REPLACEMENTS = [
+    (
+        '"skills" / "opensearch-launchpad" / "scripts"',
+        '"skills" / "opensearch-skills" / "scripts"',
+    ),
+    (
+        "skills/opensearch-launchpad/scripts/lib/",
+        "skills/opensearch-skills/scripts/lib/",
+    ),
+]
+
+
+def copy_and_replace(src: Path, dst: Path, replacements: list[tuple[str, str]]) -> None:
+    """Copy a file, applying text replacements."""
+    text = src.read_text()
+    for old, new in replacements:
+        text = text.replace(old, new)
+    dst.write_text(text)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <source_root> <target_root>")
+        sys.exit(1)
+
+    src = Path(sys.argv[1]).resolve()
+    tgt = Path(sys.argv[2]).resolve()
+
+    src_skill = src / "skills" / "opensearch-launchpad"
+    tgt_skill = tgt / "skills" / "opensearch-skills"
+    src_scripts = src_skill / "scripts"
+    tgt_scripts = tgt_skill / "scripts"
+
+    # 1. scripts/lib/* — direct copy
+    print("=== scripts/lib ===")
+    for f in sorted((src_scripts / "lib").glob("*.py")):
+        shutil.copy2(f, tgt_scripts / "lib" / f.name)
+        print(f"  {f.name}")
+
+    # 2. Patch ui.py
+    print("=== patch ui.py ===")
+    ui_py = tgt_scripts / "lib" / "ui.py"
+    text = ui_py.read_text()
+    for old, new in UI_PY_REPLACEMENTS:
+        text = text.replace(old, new)
+    ui_py.write_text(text)
+    print("  done")
+
+    # 3. scripts root files — direct copy
+    print("=== scripts root ===")
+    for name in ["opensearch_ops.py", "start_opensearch.sh"]:
+        shutil.copy2(src_scripts / name, tgt_scripts / name)
+        print(f"  {name}")
+
+    # 4. sample_data — direct copy
+    print("=== sample_data ===")
+    shutil.copy2(
+        src_scripts / "sample_data" / "imdb.title.basics.tsv",
+        tgt_scripts / "sample_data" / "imdb.title.basics.tsv",
+    )
+    print("  imdb.title.basics.tsv")
+
+    # 5. UI assets (shared/ui/ → scripts/ui/)
+    print("=== UI assets ===")
+    for name in ["app.jsx", "index.html", "styles.css"]:
+        shutil.copy2(src / "shared" / "ui" / name, tgt_scripts / "ui" / name)
+        print(f"  {name}")
+
+    # 6. Knowledge md (references/knowledge/ → launchpad/)
+    print("=== knowledge md ===")
+    for f in sorted((src_skill / "references" / "knowledge").glob("*.md")):
+        shutil.copy2(f, tgt_skill / "launchpad" / f.name)
+        print(f"  {f.name}")
+
+    # 7. Observability md
+    print("=== observability md ===")
+    for f in sorted((src_skill / "references" / "observability").glob("*.md")):
+        shutil.copy2(f, tgt_skill / "observability" / f.name)
+        print(f"  {f.name}")
+
+    # 8. AWS md — copy with link rewrites
+    print("=== aws md ===")
+    for f in sorted((src_skill / "references").glob("aws-*.md")):
+        target_name = f.name.removeprefix("aws-")
+        copy_and_replace(f, tgt_skill / "aws" / target_name, AWS_MD_REPLACEMENTS)
+        print(f"  {f.name} → aws/{target_name}")
+
+    # 9. CLI reference — direct copy
+    print("=== cli-reference ===")
+    shutil.copy2(src_skill / "references" / "cli-reference.md", tgt_skill / "cli-reference.md")
+    print("  cli-reference.md")
+
+    # 10. SKILL.md — copy with path rewrites
+    print("=== SKILL.md ===")
+    copy_and_replace(src_skill / "SKILL.md", tgt_skill / "SKILL.md", SKILL_MD_REPLACEMENTS)
+    print("  done")
+
+    # 11. Tests — copy with path rewrites (skip standalone_assets)
+    print("=== tests ===")
+    skip = {"test_agent_skills_standalone_assets.py"}
+    for f in sorted((src / "tests").glob("test_agent_skills_*.py")):
+        if f.name in skip:
+            print(f"  {f.name} (SKIPPED)")
+            continue
+        copy_and_replace(f, tgt / "tests" / f.name, TEST_REPLACEMENTS)
+        print(f"  {f.name}")
+
+    print("\n=== SYNC COMPLETE ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/sync-to-agent-skills.yml
+++ b/.github/workflows/sync-to-agent-skills.yml
@@ -1,0 +1,98 @@
+name: Sync skills to opensearch-agent-skills
+
+# Triggers when relevant files change on main
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/opensearch-launchpad/**'
+      - 'shared/ui/**'
+      - 'tests/test_agent_skills_*'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  sync:
+    name: Sync to opensearch-agent-skills
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout opensearch-launchpad (source)
+        uses: actions/checkout@v4
+        with:
+          path: source
+
+      - name: Checkout opensearch-agent-skills (target)
+        uses: actions/checkout@v4
+        with:
+          repository: opensearch-project/opensearch-agent-skills
+          token: ${{ secrets.SYNC_PAT }}
+          path: target
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v6
+
+      # ---------------------------------------------------------------
+      # Run the sync script
+      # ---------------------------------------------------------------
+      - name: Run sync
+        run: python3 source/.github/scripts/sync_to_agent_skills.py source target
+
+      # ---------------------------------------------------------------
+      # Verify
+      # ---------------------------------------------------------------
+      - name: Verify Python files parse
+        run: |
+          cd target
+          python3 -c "
+          import ast, pathlib
+          for f in pathlib.Path('skills/opensearch-skills/scripts/lib').glob('*.py'):
+              ast.parse(f.read_text())
+              print(f'  {f.name} OK')
+          for f in pathlib.Path('tests').glob('test_agent_skills_*.py'):
+              ast.parse(f.read_text())
+              print(f'  {f.name} OK')
+          "
+
+      - name: Run tests
+        run: |
+          cd target
+          uv run pytest tests/test_agent_skills_*.py -v
+
+      # ---------------------------------------------------------------
+      # Create PR if there are changes
+      # ---------------------------------------------------------------
+      - name: Check for changes
+        id: changes
+        run: |
+          cd target
+          git diff --quiet && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          path: target
+          token: ${{ secrets.SYNC_PAT }}
+          commit-message: "Sync skills from opensearch-launchpad"
+          title: "[Automated] Sync skills from opensearch-launchpad"
+          body: |
+            Automated sync from [opensearch-launchpad](https://github.com/opensearch-project/opensearch-launchpad).
+
+            Triggered by commit: ${{ github.sha }}
+
+            **Files synced:**
+            - `scripts/lib/*` — Python modules (with ui.py path patch)
+            - `scripts/ui/*` — UI assets (from `shared/ui/`)
+            - `scripts/opensearch_ops.py`, `start_opensearch.sh`, `sample_data/*`
+            - `launchpad/*.md`, `observability/*.md`, `aws/*.md`, `cli-reference.md`
+            - `SKILL.md` (with path rewrites)
+            - `tests/test_agent_skills_*` (with path rewrites, excluding standalone_assets)
+
+            Please review and run tests before merging.
+          branch: automated/sync-from-launchpad
+          delete-branch: true
+          labels: automated,sync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pandas>=2.3.3",
     "pyarrow>=23.0.1",
     "pyjwt>=2.12.0",  # CVE-2026-32597: Force upgrade from transitive dependency
+    "python-multipart>=0.0.26",  # CVE-2026-40347: Force upgrade from mcp transitive dependency
     "requests>=2.33.0",  # CVE-2026-25645: Force upgrade from opensearch-py transitive dependency
     "strands-agents",
 ]

--- a/skills/opensearch-launchpad/SKILL.md
+++ b/skills/opensearch-launchpad/SKILL.md
@@ -217,7 +217,7 @@ Ask the user whether they want to process the entire document or specific page r
 
 ### Phase 2 — Gather Preferences
 
-Ask the user **one at a time**: query pattern (keyword, semantic, hybrid, agentic) and deployment preference. Skip questions that don't apply.
+Ask the user **one at a time**: search strategy and deployment preference. Always present all five strategies — `bm25` (keyword), `dense_vector` (semantic via embeddings), `neural_sparse` (semantic via learned sparse representations), `hybrid` (combines keyword + semantic), and `agentic` (LLM-driven multi-step retrieval, requires OpenSearch 3.2+) — regardless of cluster version. Skip questions that don't apply.
 
 ### Phase 3 — Plan
 

--- a/skills/opensearch-launchpad/scripts/lib/samples.py
+++ b/skills/opensearch-launchpad/scripts/lib/samples.py
@@ -102,7 +102,7 @@ def load_sample_from_file(file_path: str) -> str:
 
 def load_sample_from_url(url: str) -> str:
     try:
-        req = urllib.request.Request(url, headers={"User-Agent": "opensearch-launchpad/1.0"})
+        req = urllib.request.Request(url, headers={"User-Agent": "opensearch-skills/1.0"})
         with urllib.request.urlopen(req, timeout=30) as resp:
             content = resp.read().decode("utf-8", errors="replace")
 

--- a/skills/opensearch-launchpad/scripts/start_opensearch.sh
+++ b/skills/opensearch-launchpad/scripts/start_opensearch.sh
@@ -32,6 +32,7 @@ docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
 echo "Starting OpenSearch..." >&2
 
 docker run -d \
+    --pull always \
     --name "$CONTAINER_NAME" \
     -p "${PORT}:9200" \
     -p 9600:9600 \

--- a/uv.lock
+++ b/uv.lock
@@ -723,6 +723,7 @@ dependencies = [
     { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyarrow" },
     { name = "pyjwt" },
+    { name = "python-multipart" },
     { name = "requests" },
     { name = "strands-agents" },
 ]
@@ -746,6 +747,7 @@ requires-dist = [
     { name = "prompt-toolkit", marker = "extra == 'cli'" },
     { name = "pyarrow", specifier = ">=23.0.1" },
     { name = "pyjwt", specifier = ">=2.12.0" },
+    { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "strands-agents" },
 ]
@@ -1309,11 +1311,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description
## Sync: opensearch-launchpad → opensearch-agent-skills

### Trigger
Push to `main` on opensearch-launchpad when `skills/opensearch-launchpad/**`, `shared/ui/**`, or `tests/test_agent_skills_*` change. Also supports manual `workflow_dispatch`.

### Directory mapping

| opensearch-launchpad | opensearch-agent-skills |
|---|---|
| `skills/opensearch-launchpad/scripts/lib/*` | `skills/opensearch-skills/scripts/lib/*` |
| `skills/opensearch-launchpad/scripts/opensearch_ops.py` | `skills/opensearch-skills/scripts/opensearch_ops.py` |
| `skills/opensearch-launchpad/scripts/start_opensearch.sh` | `skills/opensearch-skills/scripts/start_opensearch.sh` |
| `skills/opensearch-launchpad/scripts/sample_data/*` | `skills/opensearch-skills/scripts/sample_data/*` |
| `shared/ui/*` | `skills/opensearch-skills/scripts/ui/*` |
| `skills/opensearch-launchpad/references/knowledge/*.md` | `skills/opensearch-skills/launchpad/*.md` |
| `skills/opensearch-launchpad/references/observability/*.md` | `skills/opensearch-skills/observability/*.md` |
| `skills/opensearch-launchpad/references/aws-*.md` | `skills/opensearch-skills/aws/*.md` (strip `aws-` prefix) |
| `skills/opensearch-launchpad/references/cli-reference.md` | `skills/opensearch-skills/cli-reference.md` |
| `skills/opensearch-launchpad/SKILL.md` | `skills/opensearch-skills/SKILL.md` |
| `tests/test_agent_skills_*.py` | `tests/test_agent_skills_*.py` |

### Transformations applied after copy

**ui.py** (2 replacements):
- `SEARCH_UI_STATIC_DIR = Path(__file__).resolve().parents[4] / "shared" / "ui"` → `SEARCH_UI_STATIC_DIR = _SCRIPT_DIR / "ui"`
- Error message: `opensearch-launchpad repository` → `opensearch-skills skill directory`

**SKILL.md** (8 replacements):
- `name: opensearch-launchpad` → `name: opensearch-skills`
- Prerequisite text: `opensearch-launchpad repository` → `opensearch-skills skill directory`
- `references/knowledge/` → `launchpad/`
- `references/observability/` → `observability/`
- `references/cli-reference.md` → `cli-reference.md`
- `references/aws-reference.md` → `aws/reference.md`
- `references/aws-domain-` → `aws/domain-`
- `references/aws-serverless-` → `aws/serverless-`

**aws/*.md** (2 replacements per file):
- `(aws-domain-` → `(domain-`
- `(aws-serverless-` → `(serverless-`

**tests** (2 replacements per file):
- `"skills" / "opensearch-launchpad" / "scripts"` → `"skills" / "opensearch-skills" / "scripts"`
- `skills/opensearch-launchpad/scripts/lib/` → `skills/opensearch-skills/scripts/lib/`

### Excluded from sync
- `test_agent_skills_standalone_assets.py` — maintained separately in each repo (tests repo-specific directory structure)

### Safety checks
1. Python syntax verification on all `.py` files
2. Full test suite run (`uv run pytest tests/test_agent_skills_*.py`)
3. PR created only if diff exists — human review required before merge

### Local validations
**Local sync validation** (`bash test_sync.sh`):
- Reset agent-skills to committed state, ran sync script, verified all Python files parse, confirmed diff matches expected changes (UI assets + new tests)

**Unit tests**: All 119 passed (`uv run pytest tests/test_agent_skills_*.py -v`)

**Files changed in opensearch-launchpad**:
- `skills/opensearch-launchpad/scripts/lib/samples.py` — User-Agent string
- `skills/opensearch-launchpad/scripts/opensearch_ops.py` — docstring
- `skills/opensearch-launchpad/scripts/start_opensearch.sh` — `--pull always`
- `skills/opensearch-launchpad/SKILL.md` — bullet indentation
- `.github/workflows/sync-to-agent-skills.yml` — new workflow
- `.github/scripts/sync_to_agent_skills.py` — new sync script

**Files changed in opensearch-agent-skills**:
- `skills/opensearch-skills/scripts/lib/search.py` — full agentic feature sync
- `skills/opensearch-skills/scripts/lib/ui.py` — agent prompts endpoint + memory_id
- `skills/opensearch-skills/scripts/lib/client.py` — timeout
- `skills/opensearch-skills/scripts/lib/samples.py` — User-Agent string
- `skills/opensearch-skills/scripts/opensearch_ops.py` — docstring
- `skills/opensearch-skills/scripts/ui/*` — all 3 UI files replaced
- `skills/opensearch-skills/SKILL.md` — fixed 2 missing `launchpad/` prefixes
- `tests/test_agent_skills_search.py` — imports + 24 new tests
- `tests/test_agent_skills_standalone_assets.py` — frontend agentic tests

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
